### PR TITLE
chore: add missing OS and editor entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 
 # macOS
 .DS_Store
+.AppleDouble
+.LSOverride
 
 # iOS
 *.ipa
@@ -34,6 +36,8 @@ local.properties
 .vscode/
 .idea/
 *.iml
+*.swp
+*~
 
 # Misc
 *.log


### PR DESCRIPTION
## Summary
- Add `.AppleDouble` and `.LSOverride` (macOS system files) to .gitignore
- Add `*.swp` and `*~` (editor temp files) to prevent accidental commits

## Type of Change
- Documentation / config update (non-breaking)