### PR TITLE
fix(android): align ac-templating minSdk to 26

### DIFF
--- a/android/ac-templating/build.gradle.kts
+++ b/android/ac-templating/build.gradle.kts
@@ -8,7 +8,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 24
+        minSdk = 26
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
## Summary
- **Fixes minSdk inconsistency**: `ac-templating` was the only Android module with `minSdk = 24` while all 13 other modules use `minSdk = 26`
- Aligns with documented spec in CLAUDE.md ("Kotlin 1.9+, minSdk 26")
- Prevents potential API availability issues at runtime

## Details

| Module | Before | After |
|--------|--------|-------|
| ac-templating | minSdk = 24 | minSdk = 26 |
| All 13 other modules | minSdk = 26 | minSdk = 26 (unchanged) |

## Test plan
- [ ] Verify `./gradlew :ac-templating:assembleDebug` builds successfully
- [ ] Verify `./gradlew :ac-templating:test` passes
- [ ] Confirm all modules now share consistent minSdk = 26

🤖 Generated with [Claude Code](https://claude.com/claude-code)