### PR TITLE
(shared): add 19 Teams official card samples

### DIFF
--- a/android/sample-app/src/main/kotlin/com/microsoft/adaptivecards/sample/CardGalleryScreen.kt
+++ b/android/sample-app/src/main/kotlin/com/microsoft/adaptivecards/sample/CardGalleryScreen.kt
@@ -161,7 +161,8 @@ enum class CardCategory(val displayName: String) {
     TEMPLATING("Templating"),
     OFFICIAL("Official Samples"),
     ELEMENT("Element Samples"),
-    TEAMS_TEMPLATED("Teams Templated")
+    TEAMS_TEMPLATED("Teams Templated"),
+    TEAMS_OFFICIAL("Teams Official")
 }
 
 data class TestCard(
@@ -316,6 +317,27 @@ object TestCardLoader {
         Triple("teams-samples/flight-update-template.json", "Teams: Flight Update", CardCategory.TEAMS_TEMPLATED),
         Triple("teams-samples/order-confirmation-template.json", "Teams: Order Confirmation", CardCategory.TEAMS_TEMPLATED),
         Triple("teams-samples/restaurant-order-template.json", "Teams: Restaurant Order", CardCategory.TEAMS_TEMPLATED),
+
+        // --- Teams official samples (from shared/test-cards/teams-official-samples/) ---
+        Triple("teams-official-samples/account.json", "Teams: Account", CardCategory.TEAMS_OFFICIAL),
+        Triple("teams-official-samples/author-highlight-video.json", "Teams: Author Highlight Video", CardCategory.TEAMS_OFFICIAL),
+        Triple("teams-official-samples/book-a-room.json", "Teams: Book a Room", CardCategory.TEAMS_OFFICIAL),
+        Triple("teams-official-samples/cafe-menu.json", "Teams: Cafe Menu", CardCategory.TEAMS_OFFICIAL),
+        Triple("teams-official-samples/communication.json", "Teams: Communication", CardCategory.TEAMS_OFFICIAL),
+        Triple("teams-official-samples/course-video.json", "Teams: Course Video", CardCategory.TEAMS_OFFICIAL),
+        Triple("teams-official-samples/editorial.json", "Teams: Editorial", CardCategory.TEAMS_OFFICIAL),
+        Triple("teams-official-samples/expense-report.json", "Teams: Expense Report", CardCategory.TEAMS_OFFICIAL),
+        Triple("teams-official-samples/insights.json", "Teams: Insights", CardCategory.TEAMS_OFFICIAL),
+        Triple("teams-official-samples/issue.json", "Teams: Issue", CardCategory.TEAMS_OFFICIAL),
+        Triple("teams-official-samples/list.json", "Teams: List", CardCategory.TEAMS_OFFICIAL),
+        Triple("teams-official-samples/project-dashboard.json", "Teams: Project Dashboard", CardCategory.TEAMS_OFFICIAL),
+        Triple("teams-official-samples/recipe.json", "Teams: Recipe", CardCategory.TEAMS_OFFICIAL),
+        Triple("teams-official-samples/simple-event.json", "Teams: Simple Event", CardCategory.TEAMS_OFFICIAL),
+        Triple("teams-official-samples/simple-time-off-request.json", "Teams: Simple Time Off Request", CardCategory.TEAMS_OFFICIAL),
+        Triple("teams-official-samples/standard-video.json", "Teams: Standard Video", CardCategory.TEAMS_OFFICIAL),
+        Triple("teams-official-samples/team-standup-summary.json", "Teams: Team Standup Summary", CardCategory.TEAMS_OFFICIAL),
+        Triple("teams-official-samples/time-off-request.json", "Teams: Time Off Request", CardCategory.TEAMS_OFFICIAL),
+        Triple("teams-official-samples/work-item.json", "Teams: Work Item", CardCategory.TEAMS_OFFICIAL),
     )
 
     /**
@@ -407,6 +429,7 @@ object TestCardLoader {
             CardCategory.OFFICIAL -> "Official sample: $title"
             CardCategory.ELEMENT -> "Element test: $title"
             CardCategory.TEAMS_TEMPLATED -> "Teams templated: $title"
+            CardCategory.TEAMS_OFFICIAL -> "Teams official sample: $title"
             CardCategory.ALL -> "Test card: $title"
         }
     }

--- a/ios/SampleApp/CardGalleryView.swift
+++ b/ios/SampleApp/CardGalleryView.swift
@@ -132,6 +132,7 @@ struct CardGalleryView: View {
                 summaryPill("Official", count: cards.filter { $0.category == .officialSamples }.count, color: .mint)
                 summaryPill("Elements", count: cards.filter { $0.category == .elementSamples }.count, color: .cyan)
                 summaryPill("Teams", count: cards.filter { $0.category == .teamsSamples }.count, color: .pink)
+                summaryPill("T. Official", count: cards.filter { $0.category == .teamsOfficialSamples }.count, color: .indigo)
                 summaryPill("Edge", count: cards.filter { $0.category == .edgeCases }.count, color: .orange)
             }
         }
@@ -184,6 +185,7 @@ enum CardSection: String, CaseIterable, Hashable {
     case officialSamples = "Official Samples"
     case elementSamples = "Element Samples"
     case teamsSamples = "Teams Templated Samples"
+    case teamsOfficialSamples = "Teams Official Samples"
     case edgeCases = "Edge Cases"
 
     var title: String { rawValue }
@@ -194,6 +196,7 @@ enum CardSection: String, CaseIterable, Hashable {
         case .officialSamples: return "star.fill"
         case .elementSamples: return "cube"
         case .teamsSamples: return "person.2.fill"
+        case .teamsOfficialSamples: return "person.3.fill"
         case .edgeCases: return "exclamationmark.triangle"
         }
     }
@@ -204,6 +207,7 @@ enum CardSection: String, CaseIterable, Hashable {
         case .officialSamples: return .mint
         case .elementSamples: return .cyan
         case .teamsSamples: return .pink
+        case .teamsOfficialSamples: return .indigo
         case .edgeCases: return .orange
         }
     }
@@ -218,6 +222,8 @@ enum CardSection: String, CaseIterable, Hashable {
             return category == .elementSamples
         case .teamsSamples:
             return category == .teamsSamples
+        case .teamsOfficialSamples:
+            return category == .teamsOfficialSamples
         case .edgeCases:
             return category == .edgeCases
         }
@@ -236,6 +242,7 @@ enum CardCategory: String, CaseIterable, Identifiable {
     case officialSamples = "Official"
     case elementSamples = "Elements"
     case teamsSamples = "Teams Templated"
+    case teamsOfficialSamples = "Teams Official"
     case edgeCases = "Edge Cases"
 
     var id: String { rawValue }
@@ -253,6 +260,7 @@ enum CardCategory: String, CaseIterable, Identifiable {
         case .officialSamples: return .mint
         case .elementSamples: return .cyan
         case .teamsSamples: return .pink
+        case .teamsOfficialSamples: return .indigo
         case .edgeCases: return .orange
         }
     }
@@ -391,6 +399,9 @@ class TestCardLoader {
 
         // Load teams templated samples from shared/test-cards/teams-samples/
         cards.append(contentsOf: loadTeamsSamples())
+
+        // Load teams official samples from shared/test-cards/teams-official-samples/
+        cards.append(contentsOf: loadCardsFromSubdirectory("teams-official-samples", category: .teamsOfficialSamples))
 
         return cards
     }

--- a/shared/test-cards/teams-official-samples/account.json
+++ b/shared/test-cards/teams-official-samples/account.json
@@ -1,0 +1,679 @@
+{
+  "type": "AdaptiveCard",
+  "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "ColumnSet",
+      "columns": [
+        {
+          "type": "Column",
+          "width": "stretch",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "Fourth Coffee Distillery Equipment ",
+              "size": "Large",
+              "weight": "Bolder",
+              "wrap": true
+            }
+          ],
+          "verticalContentAlignment": "Center"
+        },
+        {
+          "type": "Column",
+          "targetWidth": "AtLeast:Standard",
+          "width": "auto",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "Status",
+              "wrap": true,
+              "size": "Small",
+              "weight": "Default",
+              "isSubtle": true
+            },
+            {
+              "type": "TextBlock",
+              "text": "In Progress",
+              "color": "Good",
+              "spacing": "None",
+              "size": "Small",
+              "weight": "Bolder",
+              "wrap": true
+            }
+          ],
+          "spacing": "Small"
+        },
+        {
+          "type": "Column",
+          "targetWidth": "AtLeast:Standard",
+          "width": "auto",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "Opportunity Score",
+              "size": "Small",
+              "weight": "Default",
+              "isSubtle": true,
+              "wrap": true
+            },
+            {
+              "type": "TextBlock",
+              "text": "91 - Grade A",
+              "wrap": true,
+              "weight": "Bolder",
+              "spacing": "None",
+              "size": "Small",
+              "color": "Default"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "TextBlock",
+      "text": "Opportunity",
+      "wrap": true,
+      "isSubtle": true,
+      "spacing": "None"
+    },
+    {
+      "type": "TextBlock",
+      "targetWidth": "AtMost:Narrow",
+      "text": "In Progress",
+      "color": "Good",
+      "weight": "Bolder",
+      "wrap": true
+    },
+    {
+      "type": "TextBlock",
+      "targetWidth": "AtMost:Narrow",
+      "text": "91 - Grade A",
+      "wrap": true,
+      "weight": "Bolder",
+      "spacing": "None",
+      "color": "Default"
+    },
+    {
+      "type": "Table",
+      "targetWidth": "Narrow",
+      "columns": [
+        {
+          "width": 2
+        },
+        {
+          "width": 3
+        }
+      ],
+      "rows": [
+        {
+          "type": "TableRow",
+          "cells": [
+            {
+              "type": "TableCell",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "Account",
+                  "wrap": true,
+                  "isSubtle": true
+                }
+              ]
+            },
+            {
+              "type": "TableCell",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "Fourth Coffee",
+                  "wrap": true
+                }
+              ]
+            }
+          ],
+          "verticalCellContentAlignment": "Center"
+        },
+        {
+          "type": "TableRow",
+          "cells": [
+            {
+              "type": "TableCell",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "Est. Revenue",
+                  "wrap": true,
+                  "isSubtle": true
+                }
+              ]
+            },
+            {
+              "type": "TableCell",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "$3,000,000.00",
+                  "wrap": true
+                }
+              ]
+            }
+          ],
+          "verticalCellContentAlignment": "Center"
+        },
+        {
+          "type": "TableRow",
+          "cells": [
+            {
+              "type": "TableCell",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "Owner",
+                  "wrap": true,
+                  "isSubtle": true
+                }
+              ]
+            },
+            {
+              "type": "TableCell",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "Image",
+                          "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Card-Samples/main/samples/account/assets/avatar_small.png",
+                          "width": "20px"
+                        }
+                      ],
+                      "verticalContentAlignment": "Center"
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "Reta Taylor",
+                          "wrap": true
+                        }
+                      ],
+                      "spacing": "Small",
+                      "verticalContentAlignment": "Center"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "verticalCellContentAlignment": "Center"
+        }
+      ],
+      "firstRowAsHeaders": false,
+      "showGridLines": false,
+      "spacing": "Large",
+      "separator": true
+    },
+    {
+      "type": "Container",
+      "separator": true,
+      "targetWidth": "VeryNarrow",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "Account",
+          "wrap": true,
+          "isSubtle": true
+        },
+        {
+          "type": "TextBlock",
+          "text": "Fourth Coffee",
+          "wrap": true,
+          "spacing": "None"
+        },
+        {
+          "type": "TextBlock",
+          "text": "Est. Revenue",
+          "wrap": true,
+          "isSubtle": true
+        },
+        {
+          "type": "TextBlock",
+          "text": "$3,000,000.00",
+          "wrap": true,
+          "spacing": "None"
+        },
+        {
+          "type": "TextBlock",
+          "text": "Owner",
+          "wrap": true,
+          "isSubtle": true
+        },
+        {
+          "type": "ColumnSet",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "auto",
+              "items": [
+                {
+                  "type": "Image",
+                  "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Card-Samples/main/samples/account/assets/avatar_small.png",
+                  "width": "20px"
+                }
+              ],
+              "verticalContentAlignment": "Center"
+            },
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "Reta Taylor",
+                  "wrap": true
+                }
+              ],
+              "spacing": "Small",
+              "verticalContentAlignment": "Center"
+            }
+          ],
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "ColumnSet",
+      "targetWidth": "AtLeast:Standard",
+      "columns": [
+        {
+          "type": "Column",
+          "width": 20,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "Account",
+              "wrap": true,
+              "isSubtle": true
+            },
+            {
+              "type": "TextBlock",
+              "text": "Fabrikam",
+              "wrap": true,
+              "spacing": "None"
+            }
+          ]
+        },
+        {
+          "type": "Column",
+          "width": 25,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "Est. Revenue",
+              "wrap": true,
+              "isSubtle": true
+            },
+            {
+              "type": "TextBlock",
+              "text": "$3,000,000.00",
+              "wrap": true,
+              "spacing": "None"
+            }
+          ]
+        },
+        {
+          "type": "Column",
+          "width": 25,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "Owner",
+              "wrap": true,
+              "isSubtle": true
+            },
+            {
+              "type": "ColumnSet",
+              "columns": [
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "items": [
+                    {
+                      "type": "Image",
+                      "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Card-Samples/main/samples/account/assets/avatar_small.png",
+                      "width": "20px"
+                    }
+                  ],
+                  "verticalContentAlignment": "Center"
+                },
+                {
+                  "type": "Column",
+                  "width": "stretch",
+                  "items": [
+                    {
+                      "type": "TextBlock",
+                      "text": "Reta Taylor",
+                      "wrap": true
+                    }
+                  ],
+                  "spacing": "Small",
+                  "verticalContentAlignment": "Center"
+                }
+              ],
+              "spacing": "None"
+            }
+          ]
+        },
+        {
+          "type": "Column",
+          "width": "stretch"
+        }
+      ],
+      "spacing": "Medium"
+    },
+    {
+      "type": "ColumnSet",
+      "separator": true,
+      "columns": [
+        {
+          "type": "Column",
+          "width": "auto",
+          "verticalContentAlignment": "Center",
+          "items": [
+            {
+              "type": "Image",
+              "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Card-Samples/main/samples/account/assets/avatar_large.png",
+              "style": "Person",
+              "width": "35px"
+            }
+          ]
+        },
+        {
+          "type": "Column",
+          "width": "stretch",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "Mona Kane",
+              "wrap": true
+            },
+            {
+              "type": "TextBlock",
+              "text": "Contact",
+              "wrap": true,
+              "spacing": "None",
+              "size": "Small",
+              "isSubtle": true
+            }
+          ],
+          "verticalContentAlignment": "Center",
+          "spacing": "Small"
+        },
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "ColumnSet",
+              "columns": [
+                {
+                  "type": "Column",
+                  "targetWidth": "AtLeast:Narrow",
+                  "width": "auto",
+                  "items": [
+                    {
+                      "type": "RichTextBlock",
+                      "id": "showMore1",
+                      "inlines": [
+                        {
+                          "type": "TextRun",
+                          "text": "See more",
+                          "selectAction": {
+                            "type": "Action.ToggleVisibility",
+                            "targetElements": [
+                              "showMore1",
+                              "showLess1",
+                              "showMore2",
+                              "showLess2",
+                              "chevronDown1",
+                              "chevronUp1",
+                              "chevronDown2",
+                              "chevronUp2",
+                              "moreText"
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "RichTextBlock",
+                      "id": "showLess1",
+                      "isVisible": false,
+                      "inlines": [
+                        {
+                          "type": "TextRun",
+                          "text": "See less",
+                          "selectAction": {
+                            "type": "Action.ToggleVisibility",
+                            "targetElements": [
+                              "showMore1",
+                              "showLess1",
+                              "showMore2",
+                              "showLess2",
+                              "chevronDown1",
+                              "chevronUp1",
+                              "chevronDown2",
+                              "chevronUp2",
+                              "moreText"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "verticalContentAlignment": "Center",
+                  "rtl": false
+                },
+                {
+                  "type": "Column",
+                  "targetWidth": "AtLeast:Narrow",
+                  "width": "auto",
+                  "items": [
+                    {
+                      "type": "Icon",
+                      "id": "chevronDown1",
+                      "name": "ChevronDown",
+                      "size": "xxSmall",
+                      "color": "Accent",
+                      "selectAction": {
+                        "type": "Action.ToggleVisibility",
+                        "targetElements": [
+                          "showMore1",
+                          "showLess1",
+                          "showMore2",
+                          "showLess2",
+                          "chevronDown1",
+                          "chevronUp1",
+                          "chevronDown2",
+                          "chevronUp2",
+                          "moreText"
+                        ]
+                      }
+                    },
+                    {
+                      "type": "Icon",
+                      "id": "chevronUp1",
+                      "isVisible": false,
+                      "name": "ChevronUp",
+                      "size": "xxSmall",
+                      "color": "Accent",
+                      "selectAction": {
+                        "type": "Action.ToggleVisibility",
+                        "targetElements": [
+                          "showMore1",
+                          "showLess1",
+                          "showMore2",
+                          "showLess2",
+                          "chevronDown1",
+                          "chevronUp1",
+                          "chevronDown2",
+                          "chevronUp2",
+                          "moreText"
+                        ]
+                      }
+                    }
+                  ],
+                  "verticalContentAlignment": "Bottom",
+                  "horizontalAlignment": "Center",
+                  "spacing": "None"
+                }
+              ]
+            }
+          ],
+          "verticalContentAlignment": "Center"
+        }
+      ],
+      "spacing": "ExtraLarge"
+    },
+    {
+      "type": "ColumnSet",
+      "targetWidth": "VeryNarrow",
+      "columns": [
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "RichTextBlock",
+              "id": "showMore2",
+              "inlines": [
+                {
+                  "type": "TextRun",
+                  "text": "See more",
+                  "selectAction": {
+                    "type": "Action.ToggleVisibility",
+                    "targetElements": [
+                      "showMore1",
+                      "showLess1",
+                      "showMore2",
+                      "showLess2",
+                      "chevronDown1",
+                      "chevronUp1",
+                      "chevronDown2",
+                      "chevronUp2",
+                      "moreText"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "RichTextBlock",
+              "id": "showLess2",
+              "isVisible": false,
+              "inlines": [
+                {
+                  "type": "TextRun",
+                  "text": "See less",
+                  "selectAction": {
+                    "type": "Action.ToggleVisibility",
+                    "targetElements": [
+                      "showMore1",
+                      "showLess1",
+                      "showMore2",
+                      "showLess2",
+                      "chevronDown1",
+                      "chevronUp1",
+                      "chevronDown2",
+                      "chevronUp2",
+                      "moreText"
+                    ]
+                  }
+                }
+              ]
+            }
+          ],
+          "verticalContentAlignment": "Center"
+        },
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "Icon",
+              "id": "chevronDown2",
+              "name": "ChevronDown",
+              "size": "xxSmall",
+              "color": "Accent",
+              "selectAction": {
+                "type": "Action.ToggleVisibility",
+                "targetElements": [
+                  "showMore1",
+                  "showLess1",
+                  "showMore2",
+                  "showLess2",
+                  "chevronDown1",
+                  "chevronUp1",
+                  "chevronDown2",
+                  "chevronUp2",
+                  "moreText"
+                ]
+              }
+            },
+            {
+              "type": "Icon",
+              "id": "chevronUp2",
+              "name": "ChevronUp",
+              "isVisible": false,
+              "size": "xxSmall",
+              "color": "Accent",
+              "selectAction": {
+                "type": "Action.ToggleVisibility",
+                "targetElements": [
+                  "showMore1",
+                  "showLess1",
+                  "showMore2",
+                  "showLess2",
+                  "chevronDown1",
+                  "chevronUp1",
+                  "chevronDown2",
+                  "chevronUp2",
+                  "moreText"
+                ]
+              }
+            }
+          ],
+          "verticalContentAlignment": "Bottom",
+          "horizontalAlignment": "Center",
+          "spacing": "None"
+        }
+      ],
+      "spacing": "Small"
+    },
+    {
+      "type": "TextBlock",
+      "id": "moreText",
+      "text": "More Info",
+      "isVisible": false
+    },
+    {
+      "type": "ActionSet",
+      "separator": true,
+      "actions": [
+        {
+          "type": "Action.OpenUrl",
+          "title": "View Details",
+          "url": "https://adaptivecards.io/"
+        }
+      ],
+      "spacing": "ExtraLarge"
+    }
+  ]
+}

--- a/shared/test-cards/teams-official-samples/author-highlight-video.json
+++ b/shared/test-cards/teams-official-samples/author-highlight-video.json
@@ -1,0 +1,82 @@
+{
+  "type": "AdaptiveCard",
+  "speak": "3 minute energy flow with kayo video",
+  "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Image",
+      "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Card-Samples/main/samples/author-highlight-video/assets/video_image.png",
+      "altText": "3 Minute Energy Flow with Kayo Video",
+      "style": "RoundedCorners"
+    },
+    {
+      "type": "TextBlock",
+      "text": "3 Minute Energy Flow with Kayo",
+      "wrap": true,
+      "size": "Large",
+      "weight": "Bolder"
+    },
+    {
+      "type": "ColumnSet",
+      "columns": [
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "Image",
+              "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Card-Samples/main/samples/author-highlight-video/assets/avatar.png",
+              "width": "24px",
+              "height": "24px",
+              "style": "Person",
+              "altText": "Avatar of Kayo Miwa"
+            }
+          ],
+          "verticalContentAlignment": "Center"
+        },
+        {
+          "type": "Column",
+          "width": "stretch",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "Kayo Miwa",
+              "wrap": true
+            }
+          ],
+          "spacing": "Small",
+          "verticalContentAlignment": "Center"
+        }
+      ]
+    },
+    {
+      "type": "TextBlock",
+      "targetWidth": "AtLeast:Narrow",
+      "text": "Feeling sluggish or sleepy? Try this quick 3 minute flow to awaken your body and mind! All you need is a little space, and get ready to stretch your arms and legs.",
+      "wrap": true
+    },
+    {
+      "type": "TextBlock",
+      "targetWidth": "VeryNarrow",
+      "text": "Feeling sluggish or sleepy? Try this quick 3 minute flow to awaken your body and...",
+      "wrap": true
+    },
+    {
+      "type": "ActionSet",
+      "actions": [
+        {
+          "type": "Action.OpenUrl",
+          "title": "Open",
+          "url": "https://adaptivecards.io/"
+        },
+        {
+          "type": "Action.OpenUrl",
+          "title": "Remind me",
+          "url": "https://adaptivecards.io/",
+          "iconUrl": "icon:AlertUrgent"
+        }
+      ]
+    }
+  ]
+}

--- a/shared/test-cards/teams-official-samples/book-a-room.json
+++ b/shared/test-cards/teams-official-samples/book-a-room.json
@@ -1,0 +1,376 @@
+{
+  "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+  "body": [
+    {
+      "backgroundImage": {
+        "url": "https://raw.githubusercontent.com/suzto/StarterCards/refs/heads/main/samples/book-a-room/assets/room_hero.png",
+        "verticalAlignment": "Bottom"
+      },
+      "items": [
+        {
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch"
+            },
+            {
+              "items": [
+                {
+                  "items": [
+                    {
+                      "maxLines": 0,
+                      "size": "ExtraLarge",
+                      "text": "Book a private meeting room",
+                      "type": "TextBlock",
+                      "weight": "Bolder",
+                      "wrap": true
+                    }
+                  ],
+                  "roundedCorners": true,
+                  "style": "default",
+                  "type": "Container"
+                }
+              ],
+              "type": "Column",
+              "width": "190px"
+            }
+          ],
+          "targetWidth": "AtLeast:Standard",
+          "type": "ColumnSet"
+        }
+      ],
+      "minHeight": "200px",
+      "roundedCorners": true,
+      "style": "emphasis",
+      "targetWidth": "AtLeast:Standard",
+      "type": "Container",
+      "verticalContentAlignment": "Bottom"
+    },
+    {
+      "backgroundImage": {
+        "url": "https://raw.githubusercontent.com/suzto/StarterCards/refs/heads/main/samples/book-a-room/assets/room_hero.png",
+        "verticalAlignment": "Bottom"
+      },
+      "items": [
+        {
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch"
+            },
+            {
+              "type": "Column",
+              "width": "150px"
+            }
+          ],
+          "type": "ColumnSet"
+        }
+      ],
+      "minHeight": "140px",
+      "roundedCorners": true,
+      "style": "emphasis",
+      "targetWidth": "Narrow",
+      "type": "Container",
+      "verticalContentAlignment": "Bottom"
+    },
+    {
+      "style": "RoundedCorners",
+      "targetWidth": "VeryNarrow",
+      "type": "Image",
+      "url": "https://raw.githubusercontent.com/suzto/StarterCards/refs/heads/main/samples/book-a-room/assets/room_hero.png"
+    },
+    {
+      "type": "ColumnSet",
+      "columns": [
+        {
+          "type": "Column",
+          "width": "stretch",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "The Rooftop Terrace",
+              "wrap": true,
+              "weight": "Bolder",
+              "color": "Accent"
+            },
+            {
+              "type": "ColumnSet",
+              "columns": [
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "items": [
+                    {
+                      "type": "Icon",
+                      "name": "Crown",
+                      "size": "xxSmall",
+                      "color": "Accent"
+                    }
+                  ]
+                },
+                {
+                  "type": "Column",
+                  "width": "stretch",
+                  "spacing": "ExtraSmall",
+                  "items": [
+                    {
+                      "type": "TextBlock",
+                      "text": "Executive suite",
+                      "wrap": true,
+                      "size": "Small",
+                      "color": "Default",
+                      "isSubtle": true
+                    }
+                  ]
+                }
+              ],
+              "spacing": "ExtraSmall"
+            }
+          ]
+        }
+      ],
+      "spacing": "Medium",
+      "targetWidth": "AtMost:Narrow"
+    },
+    {
+      "columns": [
+        {
+          "items": [
+            {
+              "color": "Accent",
+              "text": "The Rooftop Terrace ",
+              "type": "TextBlock",
+              "weight": "Bolder",
+              "wrap": true
+            }
+          ],
+          "type": "Column",
+          "verticalContentAlignment": "Center",
+          "width": "auto"
+        },
+        {
+          "items": [
+            {
+              "text": "·",
+              "type": "TextBlock"
+            }
+          ],
+          "spacing": "Small",
+          "targetWidth": "AtLeast:Narrow",
+          "type": "Column",
+          "width": "auto",
+          "verticalContentAlignment": "Center"
+        },
+        {
+          "items": [
+            {
+              "color": "Accent",
+              "name": "Crown",
+              "size": "xxSmall",
+              "type": "Icon"
+            }
+          ],
+          "spacing": "Small",
+          "targetWidth": "AtLeast:Narrow",
+          "type": "Column",
+          "verticalContentAlignment": "Center",
+          "width": "auto"
+        },
+        {
+          "items": [
+            {
+              "isSubtle": true,
+              "size": "Small",
+              "text": "Executive suite",
+              "type": "TextBlock",
+              "wrap": true
+            }
+          ],
+          "spacing": "Small",
+          "targetWidth": "AtLeast:Narrow",
+          "type": "Column",
+          "verticalContentAlignment": "Center",
+          "width": "stretch"
+        }
+      ],
+      "spacing": "Medium",
+      "type": "ColumnSet",
+      "targetWidth": "AtLeast:Standard"
+    },
+    {
+      "items": [
+        {
+          "errorMessage": "Start date is required",
+          "id": "date",
+          "isRequired": true,
+          "label": "Start Date",
+          "type": "Input.Date"
+        },
+        {
+          "errorMessage": "Start time is required",
+          "id": "time",
+          "isRequired": true,
+          "label": "Start Time",
+          "type": "Input.Time"
+        }
+      ],
+      "layouts": [
+        {
+          "columnSpacing": "Small",
+          "itemFit": "Fill",
+          "minItemWidth": "0px",
+          "rowSpacing": "Small",
+          "type": "Layout.Flow"
+        }
+      ],
+      "spacing": "Medium",
+      "type": "Container"
+    },
+    {
+      "choices": [
+        {
+          "title": "1 Hour",
+          "value": "1"
+        },
+        {
+          "title": "2 Hours",
+          "value": "2"
+        },
+        {
+          "title": "3 Hours",
+          "value": "3"
+        }
+      ],
+      "errorMessage": "Duration is required",
+      "id": "duration",
+      "isRequired": true,
+      "label": "Duration",
+      "spacing": "Medium",
+      "type": "Input.ChoiceSet",
+      "value": "1"
+    },
+    {
+      "id": "title",
+      "label": "Meeting or event title",
+      "placeholder": "Enter optional title",
+      "spacing": "Medium",
+      "type": "Input.Text"
+    },
+    {
+      "choices": [
+        {
+          "title": "Lunch buffet",
+          "value": "value1"
+        },
+        {
+          "title": "Dinner with appetizers",
+          "value": "value2"
+        }
+      ],
+      "id": "catering",
+      "label": "Select a catering option",
+      "spacing": "Medium",
+      "style": "expanded",
+      "type": "Input.ChoiceSet"
+    },
+    {
+      "color": "Marigold",
+      "id": "rating",
+      "label": "Rate importance of having catering services",
+      "spacing": "Small",
+      "type": "Input.Rating"
+    },
+    {
+      "columns": [
+        {
+          "items": [
+            {
+              "inlines": [
+                {
+                  "selectAction": {
+                    "targetElements": ["notes", "chevronUp", "chevronDown"],
+                    "type": "Action.ToggleVisibility"
+                  },
+                  "text": "Add notes or requests",
+                  "type": "TextRun"
+                }
+              ],
+              "targetWidth": "AtLeast:Narrow",
+              "type": "RichTextBlock"
+            },
+            {
+              "inlines": [
+                {
+                  "selectAction": {
+                    "targetElements": ["notes", "chevronUp", "chevronDown"],
+                    "type": "Action.ToggleVisibility"
+                  },
+                  "text": "Additional options",
+                  "type": "TextRun"
+                }
+              ],
+              "spacing": "None",
+              "targetWidth": "VeryNarrow",
+              "type": "RichTextBlock"
+            }
+          ],
+          "type": "Column",
+          "verticalContentAlignment": "Center",
+          "width": "auto"
+        },
+        {
+          "items": [
+            {
+              "color": "Accent",
+              "id": "chevronDown",
+              "name": "ChevronDown",
+              "size": "xxSmall",
+              "type": "Icon"
+            },
+            {
+              "color": "Accent",
+              "id": "chevronUp",
+              "isVisible": false,
+              "name": "ChevronUp",
+              "size": "xxSmall",
+              "spacing": "None",
+              "type": "Icon"
+            }
+          ],
+          "selectAction": {
+            "targetElements": ["notes", "chevronUp", "chevronDown"],
+            "type": "Action.ToggleVisibility"
+          },
+          "spacing": "Small",
+          "type": "Column",
+          "verticalContentAlignment": "Center",
+          "width": "auto"
+        }
+      ],
+      "spacing": "Medium",
+      "type": "ColumnSet"
+    },
+    {
+      "id": "notes",
+      "isMultiline": true,
+      "isVisible": false,
+      "placeholder": "Enter any additional notes or requests",
+      "spacing": "Small",
+      "type": "Input.Text"
+    },
+    {
+      "actions": [
+        {
+          "style": "positive",
+          "title": "Submit",
+          "type": "Action.Submit"
+        }
+      ],
+      "separator": true,
+      "spacing": "Medium",
+      "type": "ActionSet"
+    }
+  ],
+  "type": "AdaptiveCard",
+  "version": "1.5"
+}

--- a/shared/test-cards/teams-official-samples/cafe-menu.json
+++ b/shared/test-cards/teams-official-samples/cafe-menu.json
@@ -1,0 +1,744 @@
+{
+  "type": "AdaptiveCard",
+  "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "roundedCorners": true,
+      "backgroundImage": {
+        "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/cafe-menu/assets/hero.png"
+      },
+      "minHeight": "160px",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "Cafeteria 24",
+          "wrap": true,
+          "size": "ExtraLarge",
+          "weight": "Bolder",
+          "color": "Light"
+        }
+      ],
+      "verticalContentAlignment": "Bottom",
+      "targetWidth": "AtLeast:Narrow"
+    },
+    {
+      "type": "Container",
+      "backgroundImage": {
+        "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/cafe-menu/assets/hero.png",
+        "verticalAlignment": "Center"
+      },
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "Cafeteria 24",
+          "wrap": true,
+          "size": "ExtraLarge",
+          "color": "Light",
+          "weight": "Bolder"
+        }
+      ],
+      "verticalContentAlignment": "Bottom",
+      "minHeight": "120px",
+      "roundedCorners": true,
+      "targetWidth": "VeryNarrow"
+    },
+    {
+      "type": "Container",
+      "items": [
+        {
+          "type": "Container",
+          "items": [
+            {
+              "type": "ColumnSet",
+              "columns": [
+                {
+                  "type": "Column",
+                  "width": "stretch",
+                  "items": [
+                    {
+                      "type": "TextBlock",
+                      "text": "Menu",
+                      "wrap": true,
+                      "weight": "Bolder",
+                      "horizontalAlignment": "Center"
+                    },
+                    {
+                      "type": "Container",
+                      "backgroundImage": {
+                        "fillMode": "RepeatHorizontally",
+                        "verticalAlignment": "Center",
+                        "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/cafe-menu/assets/tabline.png"
+                      },
+                      "minHeight": "3px",
+                      "style": "default",
+                      "spacing": "None"
+                    }
+                  ]
+                },
+                {
+                  "type": "Column",
+                  "width": "stretch",
+                  "items": [
+                    {
+                      "type": "TextBlock",
+                      "text": "Info",
+                      "wrap": true,
+                      "horizontalAlignment": "Center"
+                    }
+                  ],
+                  "selectAction": {
+                    "type": "Action.ToggleVisibility",
+                    "targetElements": ["menu", "info"]
+                  }
+                }
+              ],
+              "spacing": "Large"
+            }
+          ]
+        },
+        {
+          "type": "TextBlock",
+          "text": "Today's Specials",
+          "wrap": true,
+          "size": "Small",
+          "weight": "Bolder",
+          "isSubtle": true,
+          "spacing": "Medium"
+        },
+        {
+          "type": "Container",
+          "style": "emphasis",
+          "showBorder": true,
+          "roundedCorners": true,
+          "items": [
+            {
+              "type": "ColumnSet",
+              "columns": [
+                {
+                  "type": "Column",
+                  "width": "80px",
+                  "items": [
+                    {
+                      "type": "Image",
+                      "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/cafe-menu/assets/menuItem_1.png",
+                      "style": "RoundedCorners",
+                      "width": "80px",
+                      "height": "80px"
+                    }
+                  ],
+                  "minHeight": "80px"
+                },
+                {
+                  "type": "Column",
+                  "width": "stretch",
+                  "items": [
+                    {
+                      "type": "TextBlock",
+                      "text": "Korean Fried Chicken",
+                      "wrap": true,
+                      "weight": "Bolder"
+                    },
+                    {
+                      "type": "TextBlock",
+                      "text": "Boneless Korean gochujhang or sweet garlic fried chicken over your choice of rice.",
+                      "wrap": true,
+                      "spacing": "None"
+                    },
+                    {
+                      "type": "TextBlock",
+                      "text": "• Organic",
+                      "wrap": true,
+                      "spacing": "None"
+                    },
+                    {
+                      "type": "RichTextBlock",
+                      "inlines": [
+                        {
+                          "type": "TextRun",
+                          "text": "• Farm to table - "
+                        },
+                        {
+                          "type": "TextRun",
+                          "text": "Harvest Moon Farm",
+                          "italic": true,
+                          "color": "Accent"
+                        }
+                      ],
+                      "spacing": "None"
+                    },
+                    {
+                      "type": "RichTextBlock",
+                      "inlines": [
+                        {
+                          "type": "TextRun",
+                          "text": "$12.00",
+                          "color": "Attention",
+                          "strikethrough": true
+                        },
+                        {
+                          "type": "TextRun",
+                          "text": "  $10.99",
+                          "isSubtle": true
+                        }
+                      ],
+                      "spacing": "None"
+                    }
+                  ]
+                },
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "items": [
+                    {
+                      "type": "Icon",
+                      "name": "ChevronRight",
+                      "size": "Small"
+                    }
+                  ],
+                  "verticalContentAlignment": "Center",
+                  "spacing": "ExtraSmall"
+                }
+              ],
+              "targetWidth": "AtLeast:Narrow"
+            },
+            {
+              "type": "Container",
+              "spacing": "None",
+              "targetWidth": "VeryNarrow",
+              "items": [
+                {
+                  "type": "Image",
+                  "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/cafe-menu/assets/menuItem_1.png",
+                  "width": "64px",
+                  "height": "64px",
+                  "style": "RoundedCorners"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "Korean Fried Chicken",
+                  "wrap": true,
+                  "weight": "Bolder",
+                  "spacing": "Small"
+                },
+                {
+                  "type": "RichTextBlock",
+                  "inlines": [
+                    {
+                      "type": "TextRun",
+                      "text": "$12.00",
+                      "color": "Attention",
+                      "strikethrough": true
+                    },
+                    {
+                      "type": "TextRun",
+                      "text": "  $10.99",
+                      "isSubtle": true
+                    }
+                  ],
+                  "spacing": "None"
+                }
+              ],
+              "horizontalAlignment": "Center"
+            }
+          ],
+          "spacing": "Small"
+        },
+        {
+          "type": "Container",
+          "style": "emphasis",
+          "showBorder": true,
+          "roundedCorners": true,
+          "items": [
+            {
+              "type": "ColumnSet",
+              "columns": [
+                {
+                  "type": "Column",
+                  "width": "80px",
+                  "items": [
+                    {
+                      "type": "Image",
+                      "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/cafe-menu/assets/menuItem_2.png",
+                      "style": "RoundedCorners",
+                      "width": "80px",
+                      "height": "80px"
+                    }
+                  ],
+                  "minHeight": "80px"
+                },
+                {
+                  "type": "Column",
+                  "width": "stretch",
+                  "items": [
+                    {
+                      "type": "TextBlock",
+                      "text": "Bibimbap",
+                      "wrap": true,
+                      "weight": "Bolder"
+                    },
+                    {
+                      "type": "TextBlock",
+                      "text": "Korean rice bowl with your choice of protein, vegetable toppings, egg and your choice of sauce.",
+                      "wrap": true,
+                      "spacing": "None"
+                    },
+                    {
+                      "type": "RichTextBlock",
+                      "inlines": [
+                        {
+                          "type": "TextRun",
+                          "text": "$13.00",
+                          "color": "Attention",
+                          "strikethrough": true
+                        },
+                        {
+                          "type": "TextRun",
+                          "text": "  $12.00",
+                          "isSubtle": true
+                        }
+                      ],
+                      "spacing": "None"
+                    }
+                  ]
+                },
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "items": [
+                    {
+                      "type": "Icon",
+                      "name": "ChevronRight",
+                      "size": "Small"
+                    }
+                  ],
+                  "verticalContentAlignment": "Center",
+                  "spacing": "ExtraSmall"
+                }
+              ],
+              "targetWidth": "AtLeast:Narrow"
+            },
+            {
+              "type": "Container",
+              "spacing": "None",
+              "targetWidth": "VeryNarrow",
+              "items": [
+                {
+                  "type": "Image",
+                  "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/cafe-menu/assets/menuItem_2.png",
+                  "width": "64px",
+                  "height": "64px",
+                  "style": "RoundedCorners"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "Bibimbap",
+                  "wrap": true,
+                  "weight": "Bolder",
+                  "spacing": "Small"
+                },
+                {
+                  "type": "RichTextBlock",
+                  "inlines": [
+                    {
+                      "type": "TextRun",
+                      "text": "$13.00",
+                      "color": "Attention",
+                      "strikethrough": true
+                    },
+                    {
+                      "type": "TextRun",
+                      "text": "  $12.00",
+                      "isSubtle": true
+                    }
+                  ],
+                  "spacing": "None"
+                }
+              ],
+              "horizontalAlignment": "Center"
+            }
+          ],
+          "spacing": "Small"
+        },
+        {
+          "type": "Container",
+          "style": "emphasis",
+          "showBorder": true,
+          "roundedCorners": true,
+          "items": [
+            {
+              "type": "ColumnSet",
+              "columns": [
+                {
+                  "type": "Column",
+                  "width": "80px",
+                  "items": [
+                    {
+                      "type": "Image",
+                      "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/cafe-menu/assets/menuItem_3.png",
+                      "style": "RoundedCorners",
+                      "width": "80px",
+                      "height": "80px"
+                    }
+                  ],
+                  "minHeight": "80px"
+                },
+                {
+                  "type": "Column",
+                  "width": "stretch",
+                  "items": [
+                    {
+                      "type": "TextBlock",
+                      "text": "Japchae Noodle Bowl",
+                      "wrap": true,
+                      "weight": "Bolder"
+                    },
+                    {
+                      "type": "TextBlock",
+                      "text": "Vermicelli noodles pan fried with a variety of vegetables with a sweet soy sauce.",
+                      "wrap": true,
+                      "spacing": "None"
+                    },
+                    {
+                      "type": "TextBlock",
+                      "text": "• Vegan",
+                      "wrap": true,
+                      "spacing": "None"
+                    },
+                    {
+                      "type": "RichTextBlock",
+                      "inlines": [
+                        {
+                          "type": "TextRun",
+                          "text": "• Local made - "
+                        },
+                        {
+                          "type": "TextRun",
+                          "text": "Hikari Ramen House",
+                          "italic": true,
+                          "color": "Accent"
+                        }
+                      ],
+                      "spacing": "None"
+                    },
+                    {
+                      "type": "RichTextBlock",
+                      "inlines": [
+                        {
+                          "type": "TextRun",
+                          "text": "$14.00",
+                          "color": "Attention",
+                          "strikethrough": true
+                        },
+                        {
+                          "type": "TextRun",
+                          "text": "  $11.99",
+                          "isSubtle": true
+                        }
+                      ],
+                      "spacing": "None"
+                    }
+                  ]
+                },
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "items": [
+                    {
+                      "type": "Icon",
+                      "name": "ChevronRight",
+                      "size": "Small"
+                    }
+                  ],
+                  "verticalContentAlignment": "Center",
+                  "spacing": "ExtraSmall"
+                }
+              ],
+              "targetWidth": "AtLeast:Narrow"
+            },
+            {
+              "type": "Container",
+              "spacing": "None",
+              "targetWidth": "VeryNarrow",
+              "items": [
+                {
+                  "type": "Image",
+                  "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/cafe-menu/assets/menuItem_3.png",
+                  "width": "64px",
+                  "height": "64px",
+                  "style": "RoundedCorners"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "Japchae Noodle Bowl",
+                  "wrap": true,
+                  "weight": "Bolder",
+                  "spacing": "Small"
+                },
+                {
+                  "type": "RichTextBlock",
+                  "inlines": [
+                    {
+                      "type": "TextRun",
+                      "text": "$14.00",
+                      "color": "Attention",
+                      "strikethrough": true
+                    },
+                    {
+                      "type": "TextRun",
+                      "text": "  $11.99",
+                      "isSubtle": true
+                    }
+                  ],
+                  "spacing": "None"
+                }
+              ],
+              "horizontalAlignment": "Center"
+            }
+          ],
+          "spacing": "Small"
+        }
+      ],
+      "spacing": "Large",
+      "id": "menu"
+    },
+    {
+      "type": "Container",
+      "id": "info",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "Menu",
+                  "wrap": true,
+                  "horizontalAlignment": "Center"
+                }
+              ],
+              "selectAction": {
+                "type": "Action.ToggleVisibility",
+                "targetElements": ["menu", "info"]
+              }
+            },
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "Info",
+                  "wrap": true,
+                  "weight": "Bolder",
+                  "horizontalAlignment": "Center"
+                },
+                {
+                  "type": "Container",
+                  "backgroundImage": {
+                    "fillMode": "RepeatHorizontally",
+                    "verticalAlignment": "Center",
+                    "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/cafe-menu/assets/tabline.png"
+                  },
+                  "minHeight": "3px",
+                  "style": "default",
+                  "spacing": "None"
+                }
+              ]
+            }
+          ],
+          "spacing": "Large"
+        },
+        {
+          "type": "TextBlock",
+          "text": "Food Stations",
+          "wrap": true,
+          "weight": "Bolder",
+          "size": "Large"
+        },
+        {
+          "type": "ColumnSet",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "auto",
+              "items": [
+                {
+                  "type": "Icon",
+                  "name": "Clock",
+                  "size": "xxSmall",
+                  "spacing": "ExtraSmall"
+                }
+              ],
+              "spacing": "ExtraSmall"
+            },
+            {
+              "type": "Column",
+              "width": "stretch",
+              "spacing": "ExtraSmall",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "Open Mon-Fri 8:00AM to 5:00PM",
+                  "wrap": true,
+                  "spacing": "ExtraSmall",
+                  "size": "Small",
+                  "color": "Default",
+                  "isSubtle": true,
+                  "weight": "Bolder"
+                }
+              ]
+            }
+          ],
+          "spacing": "ExtraSmall"
+        },
+        {
+          "type": "RichTextBlock",
+          "inlines": [
+            {
+              "type": "TextRun",
+              "text": "￭ Pranzetto",
+              "weight": "Bolder"
+            },
+            {
+              "type": "TextRun",
+              "text": ": Curated sandwiches on house-made focaccia, organic produce, and more"
+            }
+          ]
+        },
+        {
+          "type": "RichTextBlock",
+          "inlines": [
+            {
+              "type": "TextRun",
+              "text": "￭ Eat Local",
+              "weight": "Bolder"
+            },
+            {
+              "type": "TextRun",
+              "text": ": Rotating local brands such as Kalia, Maya’s Mexican and Facing East"
+            }
+          ]
+        },
+        {
+          "type": "RichTextBlock",
+          "inlines": [
+            {
+              "type": "TextRun",
+              "text": "￭ Diner",
+              "weight": "Bolder"
+            },
+            {
+              "type": "TextRun",
+              "text": ": All-day breakfast and lunch"
+            }
+          ]
+        },
+        {
+          "type": "RichTextBlock",
+          "inlines": [
+            {
+              "type": "TextRun",
+              "text": "￭ Grilled",
+              "weight": "Bolder"
+            },
+            {
+              "type": "TextRun",
+              "text": ": Made-to-order grilled proteins and sides"
+            }
+          ]
+        },
+        {
+          "type": "RichTextBlock",
+          "inlines": [
+            {
+              "type": "TextRun",
+              "text": "￭ Mediterranean",
+              "weight": "Bolder"
+            },
+            {
+              "type": "TextRun",
+              "text": ": An array of grilled meats, falafel wraps, mezze bowls, and fresh salads"
+            }
+          ]
+        },
+        {
+          "type": "RichTextBlock",
+          "inlines": [
+            {
+              "type": "TextRun",
+              "text": "￭ Street Food",
+              "weight": "Bolder"
+            },
+            {
+              "type": "TextRun",
+              "text": ": Ready-to-eat bites including sandwiches, tacos, and more"
+            }
+          ]
+        },
+        {
+          "type": "RichTextBlock",
+          "inlines": [
+            {
+              "type": "TextRun",
+              "text": "￭ World Flavors",
+              "weight": "Bolder"
+            },
+            {
+              "type": "TextRun",
+              "text": ": Gourmet cuisines from around the globe"
+            }
+          ]
+        },
+        {
+          "type": "RichTextBlock",
+          "inlines": [
+            {
+              "type": "TextRun",
+              "text": "￭ Sprout",
+              "weight": "Bolder"
+            },
+            {
+              "type": "TextRun",
+              "text": ": Self-service salad bar featuring a variety of toppings and gourmet soups"
+            }
+          ]
+        },
+        {
+          "type": "RichTextBlock",
+          "inlines": [
+            {
+              "type": "TextRun",
+              "text": "￭ Oma Bap",
+              "weight": "Bolder"
+            },
+            {
+              "type": "TextRun",
+              "text": ": Homestyle Korean fried chicken and bibimbap"
+            }
+          ]
+        },
+        {
+          "type": "RichTextBlock",
+          "inlines": [
+            {
+              "type": "TextRun",
+              "text": "￭ Flora",
+              "weight": "Bolder"
+            },
+            {
+              "type": "TextRun",
+              "text": ": Rotating vegan and vegetarian dishes"
+            }
+          ]
+        }
+      ],
+      "spacing": "Large",
+      "isVisible": false
+    }
+  ]
+}

--- a/shared/test-cards/teams-official-samples/communication.json
+++ b/shared/test-cards/teams-official-samples/communication.json
@@ -1,0 +1,471 @@
+{
+  "type": "AdaptiveCard",
+  "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.5",
+  "speak": "Hawaii holiday escape deals start tonight",
+  "body": [
+    {
+      "columns": [
+        {
+          "width": "auto",
+          "items": [
+            {
+              "type": "Icon",
+              "name": "Megaphone",
+              "style": "Filled",
+              "size": "xxSmall",
+              "color": "Accent"
+            }
+          ],
+          "type": "Column"
+        },
+        {
+          "width": "stretch",
+          "items": [
+            {
+              "isSubtle": true,
+              "size": "Small",
+              "text": "Posted in Employee Deals",
+              "wrap": true,
+              "type": "TextBlock"
+            }
+          ],
+          "spacing": "Small",
+          "type": "Column"
+        }
+      ],
+      "type": "ColumnSet",
+      "targetWidth": "Narrow"
+    },
+    {
+      "columns": [
+        {
+          "width": "auto",
+          "items": [
+            {
+              "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Card-Samples/main/samples/communication/assets/avatar.png",
+              "height": "auto",
+              "type": "Image",
+              "altText": "Avatar of Laurence Gibertson"
+            }
+          ],
+          "type": "Column"
+        },
+        {
+          "width": "stretch",
+          "items": [
+            {
+              "text": "Laurence Gibertson",
+              "weight": "Bolder",
+              "wrap": true,
+              "type": "TextBlock"
+            },
+            {
+              "isSubtle": true,
+              "size": "Small",
+              "text": "Oct 22",
+              "wrap": true,
+              "spacing": "None",
+              "type": "TextBlock"
+            }
+          ],
+          "type": "Column"
+        }
+      ],
+      "type": "ColumnSet",
+      "targetWidth": "Narrow"
+    },
+    {
+      "columns": [
+        {
+          "width": "stretch",
+          "items": [
+            {
+              "columns": [
+                {
+                  "width": "auto",
+                  "items": [
+                    {
+                      "type": "Icon",
+                      "name": "Megaphone",
+                      "style": "Filled",
+                      "size": "xxSmall",
+                      "color": "Accent"
+                    }
+                  ],
+                  "type": "Column"
+                },
+                {
+                  "width": "stretch",
+                  "items": [
+                    {
+                      "isSubtle": true,
+                      "size": "Small",
+                      "text": "Posted in Employee Deals",
+                      "wrap": true,
+                      "type": "TextBlock"
+                    }
+                  ],
+                  "spacing": "Small",
+                  "type": "Column"
+                }
+              ],
+              "targetWidth": "AtLeast:Standard",
+              "type": "ColumnSet"
+            },
+            {
+              "columns": [
+                {
+                  "width": "auto",
+                  "items": [
+                    {
+                      "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Card-Samples/main/samples/communication/assets/avatar.png",
+                      "height": "auto",
+                      "type": "Image",
+                      "altText": "Avatar of Laurence Gibertson"
+                    }
+                  ],
+                  "type": "Column"
+                },
+                {
+                  "width": "stretch",
+                  "items": [
+                    {
+                      "text": "Laurence Gibertson",
+                      "weight": "Bolder",
+                      "wrap": true,
+                      "type": "TextBlock"
+                    },
+                    {
+                      "isSubtle": true,
+                      "size": "Small",
+                      "text": "Oct 22",
+                      "wrap": true,
+                      "spacing": "None",
+                      "type": "TextBlock"
+                    }
+                  ],
+                  "type": "Column"
+                }
+              ],
+              "targetWidth": "AtLeast:Standard",
+              "type": "ColumnSet"
+            },
+            {
+              "size": "Large",
+              "text": "Hawaii holiday escape deals start tonight!",
+              "weight": "Bolder",
+              "wrap": true,
+              "spacing": "Small",
+              "type": "TextBlock"
+            },
+            {
+              "text": "For a limited time, you can book a four night stay at luxury resort on the island of Maui for only $999 per person.",
+              "wrap": true,
+              "spacing": "Small",
+              "type": "TextBlock",
+              "maxLines": 3
+            },
+            {
+              "columns": [
+                {
+                  "width": "auto",
+                  "items": [
+                    {
+                      "horizontalAlignment": "Right",
+                      "id": "likeOutline",
+                      "type": "Icon",
+                      "name": "ThumbLike",
+                      "size": "xxSmall"
+                    },
+                    {
+                      "horizontalAlignment": "Right",
+                      "id": "likeFilled",
+                      "type": "Icon",
+                      "name": "ThumbLike",
+                      "style": "Filled",
+                      "size": "xxSmall",
+                      "isVisible": false
+                    }
+                  ],
+                  "verticalContentAlignment": "Bottom",
+                  "spacing": "None",
+                  "type": "Column"
+                },
+                {
+                  "width": "stretch",
+                  "items": [
+                    {
+                      "size": "Small",
+                      "text": "26 people like this",
+                      "wrap": true,
+                      "id": "commentLike",
+                      "type": "TextBlock"
+                    },
+                    {
+                      "size": "Small",
+                      "text": "27 people like this",
+                      "wrap": true,
+                      "id": "commentUnlike",
+                      "isVisible": false,
+                      "type": "TextBlock"
+                    }
+                  ],
+                  "verticalContentAlignment": "Bottom",
+                  "spacing": "Small",
+                  "type": "Column"
+                }
+              ],
+              "height": "stretch",
+              "spacing": "ExtraLarge",
+              "type": "ColumnSet"
+            }
+          ],
+          "type": "Column"
+        },
+        {
+          "width": "auto",
+          "items": [
+            {
+              "targetWidth": "AtLeast:Standard",
+              "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Card-Samples/main/samples/communication/assets/hero_image.png",
+              "width": "150px",
+              "height": "auto",
+              "type": "Image",
+              "altText": "Beach Image",
+              "style": "RoundedCorners"
+            },
+            {
+              "targetWidth": "Narrow",
+              "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Card-Samples/main/samples/communication/assets/hero_image.png",
+              "width": "100px",
+              "height": "auto",
+              "type": "Image",
+              "altText": "Beach Image",
+              "style": "RoundedCorners"
+            },
+            {
+              "targetWidth": "AtLeast:Standard",
+              "actions": [
+                {
+                  "targetElements": [
+                    "likeFilled",
+                    "likeOutline",
+                    "commentLike",
+                    "commentUnlike",
+                    "likeFilled2",
+                    "likeOutline2",
+                    "commentLike2",
+                    "commentUnlike2"
+                  ],
+                  "title": "Like",
+                  "type": "Action.ToggleVisibility"
+                },
+                {
+                  "title": "Comment",
+                  "type": "Action.Submit"
+                }
+              ],
+              "spacing": "Medium",
+              "type": "ActionSet"
+            }
+          ],
+          "type": "Column"
+        }
+      ],
+      "type": "ColumnSet",
+      "targetWidth": "AtLeast:Narrow"
+    },
+    {
+      "type": "Container",
+      "targetWidth": "VeryNarrow",
+      "items": [
+        {
+          "columns": [
+            {
+              "width": "auto",
+              "items": [
+                {
+                  "type": "Icon",
+                  "name": "Megaphone",
+                  "style": "Filled",
+                  "size": "xxSmall",
+                  "color": "Accent"
+                }
+              ],
+              "type": "Column"
+            },
+            {
+              "width": "stretch",
+              "items": [
+                {
+                  "isSubtle": true,
+                  "size": "Small",
+                  "text": "Posted in Employee Deals",
+                  "wrap": true,
+                  "type": "TextBlock"
+                }
+              ],
+              "spacing": "Small",
+              "type": "Column"
+            }
+          ],
+          "type": "ColumnSet"
+        },
+        {
+          "columns": [
+            {
+              "width": "auto",
+              "items": [
+                {
+                  "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Card-Samples/main/samples/communication/assets/avatar.png",
+                  "height": "auto",
+                  "type": "Image",
+                  "altText": "Avatar of Laurence Gibertson"
+                }
+              ],
+              "type": "Column"
+            },
+            {
+              "width": "stretch",
+              "items": [
+                {
+                  "text": "Laurence Gibertson",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "type": "TextBlock"
+                },
+                {
+                  "isSubtle": true,
+                  "size": "Small",
+                  "text": "Oct 22",
+                  "wrap": true,
+                  "spacing": "None",
+                  "type": "TextBlock"
+                }
+              ],
+              "type": "Column"
+            }
+          ],
+          "type": "ColumnSet"
+        },
+        {
+          "size": "Large",
+          "text": "Hawaii holiday escape deals start tonight!",
+          "weight": "Bolder",
+          "wrap": true,
+          "spacing": "Small",
+          "type": "TextBlock"
+        },
+        {
+          "columns": [
+            {
+              "width": "stretch",
+              "items": [
+                {
+                  "maxLines": 4,
+                  "text": "For a limited time, you can book a four night stay at luxury resort on the island of Maui for only $999 per person.",
+                  "wrap": true,
+                  "spacing": "Small",
+                  "type": "TextBlock"
+                }
+              ],
+              "type": "Column"
+            },
+            {
+              "width": "auto",
+              "items": [
+                {
+                  "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Card-Samples/main/samples/communication/assets/hero_image.png",
+                  "width": "60px",
+                  "type": "Image",
+                  "style": "RoundedCorners"
+                }
+              ],
+              "type": "Column"
+            }
+          ],
+          "type": "ColumnSet"
+        },
+        {
+          "columns": [
+            {
+              "width": "auto",
+              "items": [
+                {
+                  "horizontalAlignment": "Right",
+                  "id": "likeOutline2",
+                  "type": "Icon",
+                  "name": "ThumbLike",
+                  "size": "xxSmall"
+                },
+                {
+                  "horizontalAlignment": "Right",
+                  "id": "likeFilled2",
+                  "type": "Icon",
+                  "name": "ThumbLike",
+                  "style": "Filled",
+                  "size": "xxSmall",
+                  "isVisible": false
+                }
+              ],
+              "verticalContentAlignment": "Center",
+              "spacing": "None",
+              "type": "Column"
+            },
+            {
+              "width": "stretch",
+              "items": [
+                {
+                  "size": "Small",
+                  "text": "26 people like this",
+                  "wrap": true,
+                  "id": "commentLike2",
+                  "type": "TextBlock"
+                },
+                {
+                  "size": "Small",
+                  "text": "27 people like this",
+                  "wrap": true,
+                  "id": "commentUnlike2",
+                  "isVisible": false,
+                  "type": "TextBlock"
+                }
+              ],
+              "verticalContentAlignment": "Center",
+              "spacing": "Small",
+              "type": "Column"
+            }
+          ],
+          "spacing": "ExtraLarge",
+          "type": "ColumnSet"
+        }
+      ]
+    },
+    {
+      "actions": [
+        {
+          "targetElements": [
+            "likeFilled",
+            "likeOutline",
+            "commentLike",
+            "commentUnlike",
+            "likeFilled2",
+            "likeOutline2",
+            "commentLike2",
+            "commentUnlike2"
+          ],
+          "title": "Like",
+          "type": "Action.ToggleVisibility"
+        },
+        {
+          "title": "Comment",
+          "type": "Action.Submit"
+        }
+      ],
+      "spacing": "Medium",
+      "type": "ActionSet",
+      "targetWidth": "AtMost:Narrow"
+    }
+  ]
+}

--- a/shared/test-cards/teams-official-samples/course-video.json
+++ b/shared/test-cards/teams-official-samples/course-video.json
@@ -1,0 +1,198 @@
+{
+  "type": "AdaptiveCard",
+  "speak": "Intro to graphic design, concepts video",
+  "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Image",
+      "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Card-Samples/main/samples/course-video/assets/video_image.png",
+      "selectAction": {
+        "type": "Action.OpenUrl",
+        "url": "https://adaptivecards.io/",
+        "altText": "Intro to Graphic Design: Concepts Video"
+      },
+      "style": "RoundedCorners"
+    },
+    {
+      "type": "TextBlock",
+      "text": "Intro to Graphic Design: Concepts",
+      "wrap": true,
+      "size": "Large",
+      "weight": "Bolder"
+    },
+    {
+      "type": "Rating",
+      "value": 4,
+      "count": 1160,
+      "color": "Marigold",
+      "size": "Medium",
+      "fallback": {
+        "type": "TextBlock",
+        "text": "4 Stars · 1,160",
+        "spacing": "None"
+      },
+      "spacing": "None"
+    },
+    {
+      "type": "TextBlock",
+      "text": "Course · 52m · Beginner",
+      "wrap": true,
+      "isSubtle": true,
+      "spacing": "Small"
+    },
+    {
+      "type": "ColumnSet",
+      "columns": [
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "Image",
+              "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Card-Samples/main/samples/course-video/assets/logo_image.png",
+              "width": "16px",
+              "height": "16px",
+              "altText": "Logo"
+            }
+          ],
+          "horizontalAlignment": "Center",
+          "verticalContentAlignment": "Center"
+        },
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "Sketchpad Scholars",
+              "wrap": true,
+              "weight": "Bolder"
+            }
+          ],
+          "spacing": "Small",
+          "verticalContentAlignment": "Center"
+        },
+        {
+          "type": "Column",
+          "targetWidth": "AtLeast:Standard",
+          "width": "auto",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "·"
+            }
+          ],
+          "spacing": "Small",
+          "verticalContentAlignment": "Center"
+        },
+        {
+          "type": "Column",
+          "targetWidth": "AtLeast:Standard",
+          "width": "auto",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "Tony Harper",
+              "wrap": true
+            }
+          ],
+          "spacing": "Small",
+          "verticalContentAlignment": "Center"
+        }
+      ],
+      "spacing": "None"
+    },
+    {
+      "type": "TextBlock",
+      "targetWidth": "AtLeast:Narrow",
+      "text": "This course is designed to equip you with an understanding of the key principles and tools necessary for creating compelling designs. You'll gain practical experience with creative software and learn...",
+      "wrap": true,
+      "id": "truncatedText"
+    },
+    {
+      "type": "TextBlock",
+      "targetWidth": "AtLeast:Narrow",
+      "text": "This course is designed to equip you with an understanding of the key principles and tools necessary for creating compelling designs. You'll gain practical experience with creative software and learn about design principles through hands-on projects that will help build your portfolio. Enroll now and start your journey to mastering the art of graphic design.",
+      "wrap": true,
+      "isVisible": false,
+      "id": "fullText"
+    },
+    {
+      "type": "RichTextBlock",
+      "id": "showMore",
+      "targetWidth": "AtLeast:Narrow",
+      "spacing": "None",
+      "inlines": [
+        {
+          "type": "TextRun",
+          "text": "Show more",
+          "selectAction": {
+            "type": "Action.ToggleVisibility",
+            "targetElements": [
+              "truncatedText",
+              "fullText",
+              "showMore",
+              "showLess"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "RichTextBlock",
+      "id": "showLess",
+      "targetWidth": "AtLeast:Narrow",
+      "spacing": "None",
+      "inlines": [
+        {
+          "type": "TextRun",
+          "text": "Show less",
+          "selectAction": {
+            "type": "Action.ToggleVisibility",
+            "targetElements": [
+              "truncatedText",
+              "fullText",
+              "showMore",
+              "showLess"
+            ]
+          }
+        }
+      ],
+      "isVisible": false
+    },
+    {
+      "type": "ActionSet",
+      "spacing": "Large",
+      "targetWidth": "AtLeast:Narrow",
+      "actions": [
+        {
+          "type": "Action.OpenUrl",
+          "title": "Open",
+          "url": "https://adaptivecards.io/"
+        },
+        {
+          "type": "Action.Execute",
+          "title": "Bookmark",
+          "iconUrl": "icon:Bookmark"
+        }
+      ]
+    },
+    {
+      "type": "ActionSet",
+      "spacing": "Large",
+      "targetWidth": "VeryNarrow",
+      "actions": [
+        {
+          "type": "Action.OpenUrl",
+          "title": "Open",
+          "url": "https://adaptivecards.io/"
+        },
+        {
+          "type": "Action.Execute",
+          "iconUrl": "icon:Bookmark"
+        }
+      ]
+    }
+  ]
+}

--- a/shared/test-cards/teams-official-samples/editorial.json
+++ b/shared/test-cards/teams-official-samples/editorial.json
@@ -1,0 +1,142 @@
+{
+    "type": "AdaptiveCard",
+    "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.5",
+    "minHeight": "300px",
+    "body": [
+        {
+            "type": "Container",
+            "backgroundImage": {
+                "horizontalAlignment": "Center",
+                "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples//main/samples/editorial/assets/editorialHero.png"
+            },
+            "bleed": true,
+            "minHeight": "290px",
+            "items": [
+                {
+                    "type": "TextBlock",
+                    "text": "DESIGN TALK SERIES",
+                    "wrap": true,
+                    "weight": "Bolder",
+                    "color": "Dark"
+                }
+            ],
+            "verticalContentAlignment": "Bottom",
+            "targetWidth": "AtLeast:Standard"
+        },
+        {
+            "type": "Container",
+            "backgroundImage": {
+                "horizontalAlignment": "Center",
+                "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples//main/samples/editorial/assets/editorialHero.png"
+            },
+            "bleed": true,
+            "minHeight": "180px",
+            "items": [
+                {
+                    "type": "ColumnSet",
+                    "columns": [
+                        {
+                            "type": "Column",
+                            "width": "8px"
+                        },
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "DESIGN TALK SERIES",
+                                    "wrap": true,
+                                    "weight": "Bolder",
+                                    "color": "Dark",
+                                    "spacing": "None"
+                                }
+                            ],
+                            "spacing": "None"
+                        }
+                    ]
+                },
+                {
+                    "type": "ColumnSet",
+                    "columns": [
+                        {
+                            "type": "Column",
+                            "width": "stretch"
+                        }
+                    ]
+                }
+            ],
+            "verticalContentAlignment": "Bottom",
+            "targetWidth": "AtMost:Narrow"
+        },
+        {
+            "type": "TextBlock",
+            "text": "AI-DESIGN THINKING",
+            "wrap": true,
+            "horizontalAlignment": "Center",
+            "size": "Small",
+            "weight": "Bolder",
+            "color": "Good",
+            "spacing": "Medium"
+        },
+        {
+            "type": "TextBlock",
+            "text": "Behind the design: Meet Pointe",
+            "wrap": true,
+            "horizontalAlignment": "Center",
+            "size": "ExtraLarge",
+            "weight": "Bolder"
+        },
+        {
+            "type": "TextBlock",
+            "text": "When the system is the product: on crafting the next generation of home based experiences.",
+            "wrap": true,
+            "horizontalAlignment": "Center",
+            "size": "Large",
+            "color": "Default",
+            "isSubtle": true
+        },
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": "stretch"
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Icon",
+                            "horizontalAlignment": "Center",
+                            "name": "ArrowCircleRight",
+                            "size": "Medium",
+                            "color": "Good",
+                            "style": "Filled",
+                            "selectAction": {
+                                "type": "Action.OpenUrl",
+                                "url": "https://github.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "stretch"
+                }
+            ],
+            "spacing": "Large"
+        },
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": "stretch"
+                }
+            ]
+        }
+    ]
+}

--- a/shared/test-cards/teams-official-samples/expense-report.json
+++ b/shared/test-cards/teams-official-samples/expense-report.json
@@ -1,0 +1,645 @@
+{
+  "type": "AdaptiveCard",
+  "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "TextBlock",
+      "text": "Your 'Travel to Seattle' expenses have been approved!",
+      "wrap": true,
+      "size": "Large",
+      "weight": "Bolder"
+    },
+    {
+      "type": "Container",
+      "targetWidth": "VeryNarrow",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "auto",
+              "items": [
+                {
+                  "type": "Image",
+                  "width": "44px",
+                  "height": "44px",
+                  "url": "https://github.com/OfficeDev/Microsoft-Teams-Card-Samples/blob/pabloas/set-2/samples/expense-report/assets/seattle.png?raw=true",
+                  "style": "RoundedCorners",
+                  "altText": ""
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "Travel to Seattle",
+                  "wrap": true,
+                  "weight": "Bolder"
+                },
+                {
+                  "type": "ColumnSet",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "Icon",
+                          "name": "CheckmarkCircle",
+                          "size": "xxSmall",
+                          "color": "Good"
+                        }
+                      ],
+                      "verticalContentAlignment": "Center"
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "Approved",
+                          "wrap": true,
+                          "size": "Small",
+                          "weight": "Bolder",
+                          "color": "Good"
+                        }
+                      ],
+                      "spacing": "None",
+                      "verticalContentAlignment": "Center"
+                    }
+                  ],
+                  "spacing": "ExtraSmall"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "TextBlock",
+          "text": "Fri, 7 Aug 2024 - Tue, 21 Aug 2024",
+          "wrap": true,
+          "size": "Small",
+          "isSubtle": false,
+          "color": "Default",
+          "weight": "Bolder",
+          "spacing": "ExtraSmall"
+        },
+        {
+          "type": "TextBlock",
+          "text": "Business trip to meet client to sign final contracts.",
+          "wrap": true,
+          "spacing": "ExtraSmall",
+          "size": "Small",
+          "isSubtle": true
+        }
+      ],
+      "separator": true,
+      "spacing": "Medium"
+    },
+    {
+      "type": "ColumnSet",
+      "columns": [
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "Image",
+              "width": "44px",
+              "height": "44px",
+              "url": "https://github.com/OfficeDev/Microsoft-Teams-Card-Samples/blob/pabloas/set-2/samples/expense-report/assets/seattle.png?raw=true",
+              "style": "RoundedCorners",
+              "altText": ""
+            }
+          ]
+        },
+        {
+          "type": "Column",
+          "width": "stretch",
+          "items": [
+            {
+              "type": "ColumnSet",
+              "columns": [
+                {
+                  "type": "Column",
+                  "width": "stretch",
+                  "items": [
+                    {
+                      "type": "TextBlock",
+                      "text": "Travel to Seattle",
+                      "wrap": true,
+                      "weight": "Bolder"
+                    }
+                  ],
+                  "verticalContentAlignment": "Bottom"
+                },
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "items": [
+                    {
+                      "type": "Icon",
+                      "name": "CheckmarkCircle",
+                      "size": "xxSmall",
+                      "color": "Good"
+                    }
+                  ],
+                  "verticalContentAlignment": "Center"
+                },
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "items": [
+                    {
+                      "type": "TextBlock",
+                      "text": "Approved",
+                      "wrap": true,
+                      "size": "Small",
+                      "weight": "Bolder",
+                      "color": "Good"
+                    }
+                  ],
+                  "spacing": "None",
+                  "verticalContentAlignment": "Center"
+                }
+              ]
+            },
+            {
+              "type": "TextBlock",
+              "text": "Fri, 7 Aug 2024 - Tue, 21 Aug 2024",
+              "wrap": true,
+              "size": "Small",
+              "isSubtle": false,
+              "weight": "Bolder",
+              "color": "Default",
+              "spacing": "ExtraSmall"
+            },
+            {
+              "type": "TextBlock",
+              "text": "Business trip to meet client to sign final contracts.",
+              "wrap": true,
+              "spacing": "ExtraSmall",
+              "isSubtle": true,
+              "size": "Small"
+            }
+          ]
+        }
+      ],
+      "targetWidth": "AtLeast:Narrow",
+      "spacing": "Medium"
+    },
+    {
+      "type": "ColumnSet",
+      "columns": [
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "Icon",
+              "name": "Receipt",
+              "size": "xxSmall"
+            }
+          ],
+          "verticalContentAlignment": "Center"
+        },
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "2",
+              "wrap": true,
+              "size": "Small",
+              "weight": "Bolder",
+              "color": "Default"
+            }
+          ],
+          "spacing": "ExtraSmall",
+          "verticalContentAlignment": "Center"
+        },
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "Icon",
+              "name": "Comment",
+              "size": "xxSmall"
+            }
+          ],
+          "verticalContentAlignment": "Center"
+        },
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "4",
+              "wrap": true,
+              "size": "Small",
+              "weight": "Bolder",
+              "color": "Default"
+            }
+          ],
+          "spacing": "ExtraSmall",
+          "verticalContentAlignment": "Center"
+        },
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "$790.00",
+              "wrap": true,
+              "weight": "Bolder",
+              "size": "Small"
+            }
+          ],
+          "spacing": "Medium",
+          "verticalContentAlignment": "Center"
+        },
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "Icon",
+              "name": "ChevronDown",
+              "size": "xSmall",
+              "selectAction": {
+                "type": "Action.ToggleVisibility",
+                "targetElements": ["reimbursement", "chevronUp", "chevronDown"]
+              },
+              "id": "chevronDown"
+            },
+            {
+              "type": "Icon",
+              "name": "ChevronUp",
+              "size": "xSmall",
+              "selectAction": {
+                "type": "Action.ToggleVisibility",
+                "targetElements": ["reimbursement", "chevronUp", "chevronDown"]
+              },
+              "id": "chevronUp",
+              "isVisible": false
+            }
+          ],
+          "spacing": "ExtraSmall"
+        }
+      ],
+      "horizontalAlignment": "Right",
+      "spacing": "ExtraLarge",
+      "separator": true
+    },
+    {
+      "type": "Container",
+      "style": "emphasis",
+      "roundedCorners": true,
+      "showBorder": true,
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "Reimbursement #238-29",
+          "wrap": true,
+          "size": "Small"
+        },
+        {
+          "type": "Container",
+          "items": [
+            {
+              "type": "ColumnSet",
+              "columns": [
+                {
+                  "type": "Column",
+                  "width": "auto"
+                },
+                {
+                  "type": "Column",
+                  "width": "stretch",
+                  "items": [
+                    {
+                      "type": "TextBlock",
+                      "text": "Receipts and itineraries",
+                      "wrap": true,
+                      "size": "Small"
+                    },
+                    {
+                      "type": "TextBlock",
+                      "text": "$890.00",
+                      "wrap": true,
+                      "targetWidth": "VeryNarrow",
+                      "weight": "Bolder",
+                      "spacing": "ExtraSmall",
+                      "size": "Small"
+                    }
+                  ],
+                  "spacing": "Small"
+                },
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "horizontalAlignment": "Right",
+                  "items": [
+                    {
+                      "type": "TextBlock",
+                      "text": "$890.00",
+                      "wrap": true,
+                      "weight": "Bolder",
+                      "size": "Small"
+                    }
+                  ],
+                  "targetWidth": "AtLeast:Narrow"
+                },
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "ColumnSet",
+              "columns": [
+                {
+                  "type": "Column",
+                  "width": "auto"
+                },
+                {
+                  "type": "Column",
+                  "width": "stretch",
+                  "items": [
+                    {
+                      "type": "TextBlock",
+                      "text": "Non-reimbursable amount",
+                      "wrap": true,
+                      "size": "Small"
+                    },
+                    {
+                      "type": "TextBlock",
+                      "text": "$100.00",
+                      "wrap": true,
+                      "weight": "Bolder",
+                      "spacing": "ExtraSmall",
+                      "targetWidth": "VeryNarrow",
+                      "size": "Small"
+                    }
+                  ],
+                  "spacing": "Small"
+                },
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "horizontalAlignment": "Right",
+                  "items": [
+                    {
+                      "type": "TextBlock",
+                      "text": "$100.00",
+                      "wrap": true,
+                      "weight": "Bolder",
+                      "size": "Small"
+                    }
+                  ],
+                  "targetWidth": "AtLeast:Narrow"
+                },
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "spacing": "Small"
+                }
+              ],
+              "separator": true
+            },
+            {
+              "type": "ColumnSet",
+              "columns": [
+                {
+                  "type": "Column",
+                  "width": "auto"
+                },
+                {
+                  "type": "Column",
+                  "width": "stretch",
+                  "items": [
+                    {
+                      "type": "TextBlock",
+                      "text": "Cash advance",
+                      "wrap": true,
+                      "size": "Small"
+                    },
+                    {
+                      "type": "TextBlock",
+                      "text": "$50.00",
+                      "wrap": true,
+                      "spacing": "ExtraSmall",
+                      "weight": "Bolder",
+                      "targetWidth": "VeryNarrow",
+                      "size": "Small"
+                    }
+                  ],
+                  "spacing": "Small"
+                },
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "horizontalAlignment": "Right",
+                  "items": [
+                    {
+                      "type": "TextBlock",
+                      "text": "$50.00",
+                      "wrap": true,
+                      "weight": "Bolder",
+                      "size": "Small"
+                    }
+                  ],
+                  "targetWidth": "AtLeast:Narrow"
+                },
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "spacing": "Small"
+                }
+              ],
+              "separator": true
+            },
+            {
+              "type": "ColumnSet",
+              "columns": [
+                {
+                  "type": "Column",
+                  "width": "auto"
+                },
+                {
+                  "type": "Column",
+                  "width": "stretch",
+                  "items": [
+                    {
+                      "type": "ColumnSet",
+                      "columns": [
+                        {
+                          "type": "Column",
+                          "width": "auto",
+                          "items": [
+                            {
+                              "type": "Icon",
+                              "name": "CheckmarkCircle",
+                              "size": "xxSmall",
+                              "color": "Good",
+                              "spacing": "None"
+                            }
+                          ],
+                          "targetWidth": "AtLeast:Narrow",
+                          "spacing": "None"
+                        },
+                        {
+                          "type": "Column",
+                          "width": "stretch",
+                          "items": [
+                            {
+                              "type": "TextBlock",
+                              "text": "Total reimbursement",
+                              "wrap": true,
+                              "weight": "Bolder",
+                              "size": "Small",
+                              "spacing": "None"
+                            }
+                          ],
+                          "spacing": "ExtraSmall"
+                        }
+                      ],
+                      "spacing": "None"
+                    },
+                    {
+                      "type": "ColumnSet",
+                      "spacing": "ExtraSmall",
+                      "columns": [
+                        {
+                          "type": "Column",
+                          "width": "auto",
+                          "items": [
+                            {
+                              "type": "Icon",
+                              "name": "CheckmarkCircle",
+                              "size": "xxSmall",
+                              "color": "Good"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "Column",
+                          "width": "stretch",
+                          "items": [
+                            {
+                              "type": "TextBlock",
+                              "text": "$790.00",
+                              "wrap": true,
+                              "weight": "Bolder",
+                              "size": "Small"
+                            }
+                          ],
+                          "spacing": "ExtraSmall"
+                        }
+                      ],
+                      "targetWidth": "VeryNarrow"
+                    }
+                  ],
+                  "spacing": "Small"
+                },
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "horizontalAlignment": "Right",
+                  "items": [
+                    {
+                      "type": "TextBlock",
+                      "text": "$790.00",
+                      "wrap": true,
+                      "weight": "Bolder",
+                      "size": "Small"
+                    }
+                  ],
+                  "targetWidth": "AtLeast:Narrow"
+                },
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "spacing": "Small"
+                }
+              ],
+              "separator": true
+            }
+          ],
+          "style": "default",
+          "roundedCorners": true
+        }
+      ],
+      "id": "reimbursement",
+      "spacing": "Small",
+      "isVisible": false
+    },
+    {
+      "type": "ColumnSet",
+      "columns": [
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "Image",
+              "style": "Person",
+              "url": "https://github.com/OfficeDev/Microsoft-Teams-Card-Samples/blob/pabloas/set-2/samples/expense-report/assets/Avatar.png?raw=true",
+              "width": "24px",
+              "height": "24px",
+              "altText": ""
+            }
+          ]
+        },
+        {
+          "type": "Column",
+          "width": "stretch",
+          "items": [
+            {
+              "type": "RichTextBlock",
+              "inlines": [
+                {
+                  "type": "TextRun",
+                  "text": "Approved by ",
+                  "size": "Small"
+                },
+                {
+                  "type": "TextRun",
+                  "text": "Mona Kane",
+                  "size": "Small",
+                  "weight": "Bolder"
+                }
+              ]
+            }
+          ],
+          "verticalContentAlignment": "Center"
+        }
+      ],
+      "spacing": "ExtraLarge",
+      "separator": true
+    },
+    {
+      "type": "ActionSet",
+      "spacing": "Large",
+      "actions": [
+        {
+          "type": "Action.OpenUrl",
+          "title": "View statement",
+          "url": "https://github.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples"
+        }
+      ]
+    }
+  ]
+}

--- a/shared/test-cards/teams-official-samples/insights.json
+++ b/shared/test-cards/teams-official-samples/insights.json
@@ -1,0 +1,580 @@
+{
+    "type": "AdaptiveCard",
+    "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.5",
+    "body": [
+        {
+            "type": "TextBlock",
+            "text": "Credit limit details",
+            "wrap": true,
+            "size": "Large",
+            "weight": "Bolder"
+        },
+        {
+            "type": "TextBlock",
+            "text": "StellarEdge Outdoor Equipment",
+            "wrap": true,
+            "weight": "Bolder",
+            "targetWidth": "AtMost:Narrow"
+        },
+        {
+            "type": "Badge",
+            "text": "Approved",
+            "style": "Good",
+            "appearance": "Tint",
+            "icon": "CheckmarkCircle",
+            "targetWidth": "AtMost:Narrow",
+            "spacing": "ExtraSmall",
+            "horizontalAlignment": "Left",
+            "size": "Large"
+        },
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "StellarEdge Outdoor Equipment",
+                            "size": "Default",
+                            "weight": "Bolder",
+                            "maxLines": 4,
+                            "wrap": true
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Badge",
+                            "text": "Approved",
+                            "size": "Large",
+                            "style": "Good",
+                            "appearance": "Tint",
+                            "icon": "CheckmarkCircle",
+                            "horizontalAlignment": "Right"
+                        }
+                    ]
+                }
+            ],
+            "targetWidth": "AtLeast:Standard"
+        },
+        {
+            "type": "ColumnSet",
+            "spacing": "ExtraLarge",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Current Risk Class",
+                            "wrap": true,
+                            "size": "Small",
+                            "weight": "Bolder"
+                        },
+                        {
+                            "type": "ColumnSet",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "Icon",
+                                            "name": "CheckmarkCircle",
+                                            "style": "Filled",
+                                            "color": "Good",
+                                            "size": "xSmall"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "E (Low Risk)",
+                                            "wrap": true,
+                                            "spacing": "None",
+                                            "size": "Small"
+                                        }
+                                    ],
+                                    "spacing": "ExtraSmall"
+                                }
+                            ],
+                            "spacing": "ExtraSmall"
+                        }
+                    ],
+                    "verticalContentAlignment": "Center"
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Requested by",
+                            "wrap": true,
+                            "size": "Small",
+                            "weight": "Bolder"
+                        },
+                        {
+                            "type": "ColumnSet",
+                            "spacing": "ExtraSmall",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "Image",
+                                            "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/insights/assets/avatar-requestor.png",
+                                            "style": "Person",
+                                            "size": "Small",
+                                            "width": "20px"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Mark Fullbright",
+                                            "wrap": true,
+                                            "size": "Small"
+                                        }
+                                    ],
+                                    "spacing": "Small"
+                                }
+                            ]
+                        }
+                    ],
+                    "verticalContentAlignment": "Center",
+                    "spacing": "ExtraLarge"
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Approvers",
+                            "wrap": true,
+                            "size": "Small",
+                            "weight": "Bolder"
+                        },
+                        {
+                            "type": "ColumnSet",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "Image",
+                                            "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/insights/assets/avatar-approver1.png",
+                                            "width": "20px",
+                                            "style": "Person"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "Image",
+                                            "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/insights/assets/avatar-approver2.png",
+                                            "width": "20px",
+                                            "style": "Person"
+                                        }
+                                    ],
+                                    "spacing": "Small"
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "Image",
+                                            "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/insights/assets/avatar-approver3.png",
+                                            "width": "20px",
+                                            "style": "Person"
+                                        }
+                                    ],
+                                    "spacing": "Small"
+                                }
+                            ],
+                            "spacing": "ExtraSmall"
+                        }
+                    ],
+                    "spacing": "ExtraLarge"
+                }
+            ],
+            "targetWidth": "AtLeast:Standard"
+        },
+        {
+            "type": "Container",
+            "items": [
+                {
+                    "type": "TextBlock",
+                    "text": "Current Risk Class",
+                    "wrap": true,
+                    "size": "Small",
+                    "weight": "Bolder",
+                    "color": "Default"
+                },
+                {
+                    "type": "ColumnSet",
+                    "columns": [
+                        {
+                            "type": "Column",
+                            "width": "auto",
+                            "items": [
+                                {
+                                    "type": "Icon",
+                                    "name": "CheckmarkCircle",
+                                    "size": "xSmall",
+                                    "style": "Filled",
+                                    "color": "Good"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "spacing": "ExtraSmall",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "E (Low Risk)",
+                                    "wrap": true,
+                                    "size": "Small",
+                                    "color": "Default"
+                                }
+                            ]
+                        }
+                    ],
+                    "spacing": "ExtraSmall"
+                },
+                {
+                    "type": "TextBlock",
+                    "text": "Requested by",
+                    "wrap": true,
+                    "size": "Small",
+                    "weight": "Bolder",
+                    "color": "Default"
+                },
+                {
+                    "type": "ColumnSet",
+                    "columns": [
+                        {
+                            "type": "Column",
+                            "width": "auto",
+                            "items": [
+                                {
+                                    "type": "Image",
+                                    "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/insights/assets/avatar-requestor.png",
+                                    "width": "20px",
+                                    "style": "Person"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Mark Fullbright",
+                                    "wrap": true,
+                                    "size": "Small",
+                                    "color": "Default"
+                                }
+                            ],
+                            "spacing": "Small"
+                        }
+                    ],
+                    "spacing": "ExtraSmall"
+                },
+                {
+                    "type": "TextBlock",
+                    "text": "Approvers",
+                    "wrap": true,
+                    "size": "Small",
+                    "weight": "Bolder",
+                    "color": "Default"
+                },
+                {
+                    "type": "ColumnSet",
+                    "columns": [
+                        {
+                            "type": "Column",
+                            "width": "auto",
+                            "items": [
+                                {
+                                    "type": "Image",
+                                    "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/insights/assets/avatar-approver1.png",
+                                    "width": "20px",
+                                    "style": "Person"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Column",
+                            "width": "auto",
+                            "spacing": "ExtraSmall",
+                            "items": [
+                                {
+                                    "type": "Image",
+                                    "width": "20px",
+                                    "style": "Person",
+                                    "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/insights/assets/avatar-approver2.png"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Column",
+                            "width": "auto",
+                            "spacing": "ExtraSmall",
+                            "items": [
+                                {
+                                    "type": "Image",
+                                    "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/insights/assets/avatar-approver3.png",
+                                    "width": "20px",
+                                    "style": "Person"
+                                }
+                            ]
+                        }
+                    ],
+                    "spacing": "ExtraSmall"
+                }
+            ],
+            "targetWidth": "AtMost:Narrow",
+            "spacing": "Medium"
+        },
+        {
+            "type": "TextBlock",
+            "text": "Current Credit Management Data",
+            "wrap": true,
+            "spacing": "ExtraLarge",
+            "size": "Small",
+            "weight": "Bolder"
+        },
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                        {
+                            "type": "Container",
+                            "targetWidth": "AtLeast:VeryNarrow",
+                            "items": [
+                                {
+                                    "type": "ColumnSet",
+                                    "columns": [
+                                        {
+                                            "type": "Column",
+                                            "width": "stretch",
+                                            "items": [
+                                                {
+                                                    "type": "TextBlock",
+                                                    "text": "Current Credit Limit",
+                                                    "wrap": true,
+                                                    "size": "Small",
+                                                    "color": "Default",
+                                                    "isSubtle": true
+                                                },
+                                                {
+                                                    "type": "TextBlock",
+                                                    "text": "50.000.000 USD",
+                                                    "wrap": true,
+                                                    "spacing": "ExtraSmall",
+                                                    "size": "Small",
+                                                    "weight": "Bolder",
+                                                    "color": "Default"
+                                                },
+                                                {
+                                                    "type": "TextBlock",
+                                                    "text": "Credit Exposure",
+                                                    "wrap": true,
+                                                    "size": "Small",
+                                                    "color": "Default",
+                                                    "isSubtle": true
+                                                },
+                                                {
+                                                    "type": "TextBlock",
+                                                    "text": "34.184 USD",
+                                                    "wrap": true,
+                                                    "spacing": "ExtraSmall",
+                                                    "weight": "Bolder",
+                                                    "size": "Small"
+                                                },
+                                                {
+                                                    "type": "TextBlock",
+                                                    "text": "Limit Utilization",
+                                                    "wrap": true,
+                                                    "size": "Small",
+                                                    "color": "Default",
+                                                    "isSubtle": true
+                                                },
+                                                {
+                                                    "type": "TextBlock",
+                                                    "text": "68,4",
+                                                    "wrap": true,
+                                                    "spacing": "ExtraSmall",
+                                                    "size": "Small",
+                                                    "weight": "Bolder",
+                                                    "color": "Default"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "targetWidth": "VeryNarrow"
+        },
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Current Credit Limit",
+                            "wrap": true,
+                            "size": "Small",
+                            "color": "Default",
+                            "isSubtle": true
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "50.000.000 USD",
+                            "wrap": true,
+                            "spacing": "ExtraSmall",
+                            "size": "Small",
+                            "weight": "Bolder"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Credit Exposure",
+                            "wrap": true,
+                            "size": "Small",
+                            "color": "Default",
+                            "isSubtle": true
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "34.184 USD",
+                            "wrap": true,
+                            "spacing": "ExtraSmall",
+                            "size": "Small",
+                            "weight": "Bolder"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Limit Utilization",
+                            "wrap": true,
+                            "size": "Small",
+                            "color": "Default",
+                            "isSubtle": true
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "68,4",
+                            "wrap": true,
+                            "spacing": "ExtraSmall",
+                            "size": "Small",
+                            "weight": "Bolder"
+                        }
+                    ]
+                }
+            ],
+            "targetWidth": "AtLeast:Narrow"
+        },
+        {
+            "type": "ActionSet",
+            "spacing": "ExtraLarge",
+            "actions": [
+                {
+                    "type": "Action.ShowCard",
+                    "title": "Show graphical data",
+                    "card": {
+                        "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+                        "type": "AdaptiveCard",
+                        "version": "1.5",
+                        "body": [
+                            {
+                                "type": "ColumnSet",
+                                "columns": [
+                                    {
+                                        "type": "Column",
+                                        "width": 1,
+                                        "items": [
+                                            {
+                                                "type": "Chart.Donut",
+                                                "data": [
+                                                    {
+                                                        "legend": "Limit",
+                                                        "value": 100
+                                                    },
+                                                    {
+                                                        "legend": "Exposure",
+                                                        "value": 700
+                                                    },
+                                                    {
+                                                        "legend": "Utilization",
+                                                        "value": 1600
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "type": "ActionSet",
+                                                "actions": [
+                                                    {
+                                                        "type": "Action.OpenUrl",
+                                                        "title": "Open analyzer",
+                                                        "url": "https://www.microsoft.com/en-us/"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/shared/test-cards/teams-official-samples/issue.json
+++ b/shared/test-cards/teams-official-samples/issue.json
@@ -1,0 +1,376 @@
+{
+  "type": "AdaptiveCard",
+  "speak": "Version 2.2 performance optimization",
+  "body": [
+    {
+      "inlines": [
+        {
+          "type": "TextRun",
+          "size": "Small",
+          "text": "Android Scrum Project / SSP-98",
+          "selectAction": {
+            "url": "https://adaptivecards.io",
+            "type": "Action.OpenUrl"
+          }
+        }
+      ],
+      "type": "RichTextBlock"
+    },
+    {
+      "columns": [
+        {
+          "width": "auto",
+          "items": [
+            {
+              "type": "Icon",
+              "name": "Branch",
+              "color": "Accent"
+            }
+          ],
+          "type": "Column"
+        },
+        {
+          "width": "stretch",
+          "items": [
+            {
+              "size": "Large",
+              "text": "Version 2.2 Performance Optimization",
+              "weight": "Bolder",
+              "wrap": true,
+              "type": "TextBlock"
+            }
+          ],
+          "verticalContentAlignment": "Center",
+          "spacing": "Small",
+          "type": "Column"
+        }
+      ],
+      "spacing": "Small",
+      "type": "ColumnSet"
+    },
+    {
+      "type": "Table",
+      "targetWidth": "AtLeast:Narrow",
+      "columns": [
+        {
+          "width": 1
+        },
+        {
+          "width": 2
+        }
+      ],
+      "rows": [
+        {
+          "type": "TableRow",
+          "cells": [
+            {
+              "type": "TableCell",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "Status",
+                  "wrap": true,
+                  "weight": "Bolder"
+                }
+              ],
+              "verticalContentAlignment": "Center"
+            },
+            {
+              "type": "TableCell",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "Waiting for Review",
+                  "wrap": true
+                }
+              ],
+              "verticalContentAlignment": "Center"
+            }
+          ]
+        },
+        {
+          "type": "TableRow",
+          "cells": [
+            {
+              "type": "TableCell",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "Due Date",
+                  "wrap": true,
+                  "weight": "Bolder"
+                }
+              ]
+            },
+            {
+              "type": "TableCell",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "May 21, 2023",
+                  "wrap": true
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "TableRow",
+          "cells": [
+            {
+              "type": "TableCell",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "Priority",
+                  "wrap": true,
+                  "weight": "Bolder"
+                }
+              ],
+              "verticalContentAlignment": "Center"
+            },
+            {
+              "type": "TableCell",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "Icon",
+                          "name": "Flag",
+                          "color": "Attention",
+                          "size": "xSmall",
+                          "horizontalAlignment": "Center"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "color": "Attention",
+                          "text": "Critical",
+                          "wrap": true,
+                          "spacing": "Small",
+                          "type": "TextBlock"
+                        }
+                      ],
+                      "spacing": "Small"
+                    }
+                  ],
+                  "spacing": "Small"
+                }
+              ],
+              "verticalContentAlignment": "Center"
+            }
+          ]
+        },
+        {
+          "type": "TableRow",
+          "cells": [
+            {
+              "type": "TableCell",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "Assigned To",
+                  "wrap": true,
+                  "weight": "Bolder"
+                }
+              ],
+              "verticalContentAlignment": "Center"
+            },
+            {
+              "type": "TableCell",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "Image",
+                          "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Card-Samples/main/samples/issue/assets/avatar.png",
+                          "width": "16px"
+                        }
+                      ],
+                      "verticalContentAlignment": "Center",
+                      "horizontalAlignment": "Center"
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "Charlotte Waltson",
+                          "wrap": true
+                        }
+                      ],
+                      "spacing": "Small"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "firstRowAsHeaders": false,
+      "showGridLines": false
+    },
+    {
+      "type": "Container",
+      "targetWidth": "VeryNarrow",
+      "items": [
+        {
+          "text": "Status",
+          "weight": "Bolder",
+          "wrap": true,
+          "type": "TextBlock"
+        },
+        {
+          "text": "Waiting for Review",
+          "wrap": true,
+          "type": "TextBlock",
+          "spacing": "None"
+        },
+        {
+          "text": "Due Date",
+          "weight": "Bolder",
+          "wrap": true,
+          "spacing": "Small",
+          "type": "TextBlock"
+        },
+        {
+          "text": "May 21, 2023",
+          "wrap": true,
+          "spacing": "None",
+          "type": "TextBlock"
+        },
+        {
+          "text": "Priority",
+          "weight": "Bolder",
+          "wrap": true,
+          "spacing": "Small",
+          "type": "TextBlock"
+        },
+        {
+          "type": "ColumnSet",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "auto",
+              "items": [
+                {
+                  "type": "Icon",
+                  "name": "Flag",
+                  "color": "Attention",
+                  "size": "xSmall",
+                  "horizontalAlignment": "Center"
+                }
+              ],
+              "verticalContentAlignment": "Center"
+            },
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "color": "Attention",
+                  "text": "Critical",
+                  "wrap": true,
+                  "spacing": "Small",
+                  "type": "TextBlock"
+                }
+              ],
+              "spacing": "Small"
+            }
+          ],
+          "spacing": "None"
+        },
+        {
+          "text": "Assigned To",
+          "weight": "Bolder",
+          "wrap": true,
+          "spacing": "Small",
+          "type": "TextBlock"
+        },
+        {
+          "type": "ColumnSet",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "auto",
+              "items": [
+                {
+                  "type": "Image",
+                  "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Card-Samples/main/samples/issue/assets/avatar.png",
+                  "width": "16px"
+                }
+              ],
+              "verticalContentAlignment": "Center",
+              "horizontalAlignment": "Center"
+            },
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "Charlotte Waltson",
+                  "wrap": true
+                }
+              ],
+              "spacing": "Small"
+            }
+          ],
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "actions": [
+        {
+          "title": "Comment",
+          "type": "Action.OpenUrl",
+          "url": "https://adaptivecards.io/"
+        },
+        {
+          "title": "Edit Issue",
+          "type": "Action.OpenUrl",
+          "url": "https://adaptivecards.io/"
+        }
+      ],
+      "type": "ActionSet",
+      "targetWidth": "AtLeast:Narrow",
+      "spacing": "ExtraLarge"
+    },
+    {
+      "actions": [
+        {
+          "title": "Comment",
+          "type": "Action.OpenUrl",
+          "url": "https://adaptivecards.io/"
+        },
+        {
+          "type": "Action.OpenUrl",
+          "url": "https://adaptivecards.io/",
+          "iconUrl": "icon:Edit"
+        }
+      ],
+      "type": "ActionSet",
+      "targetWidth": "VeryNarrow",
+      "spacing": "ExtraLarge"
+    }
+  ],
+  "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.5"
+}

--- a/shared/test-cards/teams-official-samples/list.json
+++ b/shared/test-cards/teams-official-samples/list.json
@@ -1,0 +1,633 @@
+{
+  "type": "AdaptiveCard",
+  "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.5",
+  "speak": "Robin, explore your weekly picks",
+  "body": [
+    {
+      "type": "TextBlock",
+      "size": "Large",
+      "text": "Robin, explore your weekly picks",
+      "weight": "Bolder",
+      "wrap": true
+    },
+    {
+      "type": "TextBlock",
+      "text": "These resources will teach you how to achieve balance in your life and work with more ease.",
+      "wrap": true,
+      "targetWidth": "AtLeast:Narrow",
+      "spacing": "Small"
+    },
+    {
+      "items": [
+        {
+          "columns": [
+            {
+              "width": "auto",
+              "items": [
+                {
+                  "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Card-Samples/main/samples/list/assets/ResourceImage_1.png",
+                  "width": "56px",
+                  "height": "56px",
+                  "type": "Image",
+                  "altText": "Zenith Health Video",
+                  "style": "RoundedCorners"
+                }
+              ],
+              "type": "Column"
+            },
+            {
+              "width": "stretch",
+              "items": [
+                {
+                  "isSubtle": true,
+                  "size": "Small",
+                  "text": "Video · 12min",
+                  "wrap": true,
+                  "type": "TextBlock"
+                },
+                {
+                  "text": "Why You Should Take a Break from Screen Time and Enjoy Nature",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None",
+                  "type": "TextBlock"
+                },
+                {
+                  "text": "Zenith Health",
+                  "wrap": true,
+                  "spacing": "None",
+                  "type": "TextBlock"
+                }
+              ],
+              "type": "Column"
+            }
+          ],
+          "type": "ColumnSet"
+        }
+      ],
+      "style": "emphasis",
+      "spacing": "Medium",
+      "targetWidth": "AtLeast:Narrow",
+      "selectAction": {
+        "type": "Action.OpenUrl",
+        "url": "https://adaptivecards.io/"
+      },
+      "type": "Container",
+      "roundedCorners": true,
+      "showBorder": true
+    },
+    {
+      "items": [
+        {
+          "columns": [
+            {
+              "width": "auto",
+              "items": [
+                {
+                  "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Card-Samples/main/samples/list/assets/ResourceImage_2.png",
+                  "width": "56px",
+                  "height": "56px",
+                  "type": "Image",
+                  "altText": "Emma Jones Article",
+                  "style": "RoundedCorners"
+                }
+              ],
+              "type": "Column"
+            },
+            {
+              "width": "stretch",
+              "items": [
+                {
+                  "isSubtle": true,
+                  "size": "Small",
+                  "text": "Article · 5min",
+                  "wrap": true,
+                  "type": "TextBlock"
+                },
+                {
+                  "text": "Stay Healthy and Productive Working from Home",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None",
+                  "type": "TextBlock"
+                },
+                {
+                  "text": "Emma Jones",
+                  "wrap": true,
+                  "spacing": "None",
+                  "type": "TextBlock"
+                }
+              ],
+              "type": "Column"
+            }
+          ],
+          "type": "ColumnSet"
+        }
+      ],
+      "style": "emphasis",
+      "spacing": "Small",
+      "targetWidth": "AtLeast:Narrow",
+      "selectAction": {
+        "type": "Action.OpenUrl",
+        "url": "https://adaptivecards.io/"
+      },
+      "type": "Container",
+      "roundedCorners": true,
+      "showBorder": true
+    },
+    {
+      "items": [
+        {
+          "columns": [
+            {
+              "width": "auto",
+              "items": [
+                {
+                  "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Card-Samples/main/samples/list/assets/ResourceImage_3.png",
+                  "width": "56px",
+                  "height": "56px",
+                  "type": "Image",
+                  "altText": "Insightia Course",
+                  "style": "RoundedCorners"
+                }
+              ],
+              "type": "Column"
+            },
+            {
+              "width": "stretch",
+              "items": [
+                {
+                  "isSubtle": true,
+                  "size": "Small",
+                  "text": "Course · 30min",
+                  "wrap": true,
+                  "type": "TextBlock"
+                },
+                {
+                  "text": "Productivity Mastery: How to Optimize Your Energy, Focus and Motivation",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None",
+                  "type": "TextBlock"
+                },
+                {
+                  "text": "Insightia",
+                  "wrap": true,
+                  "spacing": "None",
+                  "type": "TextBlock"
+                }
+              ],
+              "type": "Column"
+            }
+          ],
+          "type": "ColumnSet"
+        }
+      ],
+      "style": "emphasis",
+      "spacing": "Small",
+      "targetWidth": "AtLeast:Narrow",
+      "selectAction": {
+        "type": "Action.OpenUrl",
+        "url": "https://adaptivecards.io/"
+      },
+      "type": "Container",
+      "roundedCorners": true,
+      "showBorder": true
+    },
+    {
+      "type": "Container",
+      "targetWidth": "VeryNarrow",
+      "items": [
+        {
+          "text": "Learn how to achieve balance in life and work.",
+          "wrap": true,
+          "type": "TextBlock"
+        },
+        {
+          "type": "Container",
+          "id": "content1",
+          "items": [
+            {
+              "type": "Container",
+              "backgroundImage": {
+                "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Card-Samples/main/samples/list/assets/ResourceImage_1_Horizontal.png",
+                "verticalAlignment": "Center",
+                "horizontalAlignment": "Center"
+              },
+              "bleed": true,
+              "minHeight": "128px",
+              "items": [
+                {
+                  "type": "TextBlock"
+                }
+              ],
+              "selectAction": {
+                "type": "Action.OpenUrl",
+                "url": "https://adaptivecards.io/"
+              }
+            },
+            {
+              "type": "ColumnSet",
+              "horizontalAlignment": "Center",
+              "columns": [
+                {
+                  "type": "Column",
+                  "width": "stretch",
+                  "items": [
+                    {
+                      "type": "Icon",
+                      "name": "ChevronLeft",
+                      "color": "Accent",
+                      "size": "xSmall",
+                      "horizontalAlignment": "Right",
+                      "selectAction": {
+                        "type": "Action.ToggleVisibility",
+                        "targetElements": ["content1", "content3"]
+                      }
+                    }
+                  ],
+                  "verticalContentAlignment": "Center",
+                  "horizontalAlignment": "Center"
+                },
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "items": [
+                    {
+                      "type": "Icon",
+                      "name": "CircleSmall",
+                      "color": "Accent",
+                      "style": "Filled",
+                      "size": "Small",
+                      "horizontalAlignment": "Center"
+                    }
+                  ],
+                  "verticalContentAlignment": "Center"
+                },
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "items": [
+                    {
+                      "type": "Icon",
+                      "name": "CircleSmall",
+                      "color": "Accent",
+                      "size": "Small",
+                      "horizontalAlignment": "Center",
+                      "selectAction": {
+                        "type": "Action.ToggleVisibility",
+                        "targetElements": ["content1", "content2"]
+                      }
+                    }
+                  ],
+                  "verticalContentAlignment": "Center"
+                },
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "items": [
+                    {
+                      "type": "Icon",
+                      "name": "CircleSmall",
+                      "color": "Accent",
+                      "size": "Small",
+                      "horizontalAlignment": "Center",
+                      "selectAction": {
+                        "type": "Action.ToggleVisibility",
+                        "targetElements": ["content1", "content3"]
+                      }
+                    }
+                  ],
+                  "verticalContentAlignment": "Center"
+                },
+                {
+                  "type": "Column",
+                  "width": "stretch",
+                  "items": [
+                    {
+                      "type": "Icon",
+                      "name": "ChevronRight",
+                      "color": "Accent",
+                      "size": "xSmall",
+                      "horizontalAlignment": "Left",
+                      "selectAction": {
+                        "type": "Action.ToggleVisibility",
+                        "targetElements": ["content1", "content2"]
+                      }
+                    }
+                  ],
+                  "verticalContentAlignment": "Center"
+                }
+              ]
+            },
+            {
+              "text": "Why You Should Take a Break from Screen Time and Enjoy Nature",
+              "weight": "Bolder",
+              "wrap": true,
+              "type": "TextBlock",
+              "horizontalAlignment": "Center"
+            },
+            {
+              "isSubtle": true,
+              "size": "Small",
+              "text": "Video · 12min",
+              "wrap": true,
+              "type": "TextBlock",
+              "spacing": "None",
+              "horizontalAlignment": "Center"
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "id": "content2",
+          "items": [
+            {
+              "type": "Container",
+              "backgroundImage": {
+                "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Card-Samples/main/samples/list/assets/ResourceImage_2_Horizontal.png",
+                "verticalAlignment": "Center",
+                "horizontalAlignment": "Center"
+              },
+              "bleed": true,
+              "minHeight": "128px",
+              "items": [
+                {
+                  "type": "TextBlock"
+                }
+              ],
+              "selectAction": {
+                "type": "Action.OpenUrl",
+                "url": "https://adaptivecards.io/"
+              }
+            },
+            {
+              "type": "ColumnSet",
+              "horizontalAlignment": "Center",
+              "columns": [
+                {
+                  "type": "Column",
+                  "width": "stretch",
+                  "items": [
+                    {
+                      "type": "Icon",
+                      "name": "ChevronLeft",
+                      "color": "Accent",
+                      "size": "xSmall",
+                      "horizontalAlignment": "Right",
+                      "selectAction": {
+                        "type": "Action.ToggleVisibility",
+                        "targetElements": ["content1", "content2"]
+                      }
+                    }
+                  ],
+                  "verticalContentAlignment": "Center",
+                  "horizontalAlignment": "Center"
+                },
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "items": [
+                    {
+                      "type": "Icon",
+                      "name": "CircleSmall",
+                      "color": "Accent",
+                      "size": "Small",
+                      "horizontalAlignment": "Center",
+                      "selectAction": {
+                        "type": "Action.ToggleVisibility",
+                        "targetElements": ["content1", "content2"]
+                      }
+                    }
+                  ],
+                  "verticalContentAlignment": "Center"
+                },
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "items": [
+                    {
+                      "type": "Icon",
+                      "name": "CircleSmall",
+                      "color": "Accent",
+                      "style": "Filled",
+                      "size": "Small",
+                      "horizontalAlignment": "Center"
+                    }
+                  ],
+                  "verticalContentAlignment": "Center"
+                },
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "items": [
+                    {
+                      "type": "Icon",
+                      "name": "CircleSmall",
+                      "color": "Accent",
+                      "size": "Small",
+                      "horizontalAlignment": "Center",
+                      "selectAction": {
+                        "type": "Action.ToggleVisibility",
+                        "targetElements": ["content2", "content3"]
+                      }
+                    }
+                  ],
+                  "verticalContentAlignment": "Center"
+                },
+                {
+                  "type": "Column",
+                  "width": "stretch",
+                  "items": [
+                    {
+                      "type": "Icon",
+                      "name": "ChevronRight",
+                      "color": "Accent",
+                      "size": "xSmall",
+                      "horizontalAlignment": "Left",
+                      "selectAction": {
+                        "type": "Action.ToggleVisibility",
+                        "targetElements": ["content2", "content3"]
+                      }
+                    }
+                  ],
+                  "verticalContentAlignment": "Center"
+                }
+              ]
+            },
+            {
+              "text": "Stay Healthy and Productive Working from Home",
+              "weight": "Bolder",
+              "wrap": true,
+              "type": "TextBlock",
+              "horizontalAlignment": "Center"
+            },
+            {
+              "isSubtle": true,
+              "size": "Small",
+              "text": "Article · 5min",
+              "wrap": true,
+              "type": "TextBlock",
+              "spacing": "None",
+              "horizontalAlignment": "Center"
+            }
+          ],
+          "isVisible": false
+        },
+        {
+          "type": "Container",
+          "id": "content3",
+          "items": [
+            {
+              "type": "Container",
+              "backgroundImage": {
+                "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Card-Samples/main/samples/list/assets/ResourceImage_3_Horizontal.png",
+                "verticalAlignment": "Center",
+                "horizontalAlignment": "Center"
+              },
+              "bleed": true,
+              "minHeight": "128px",
+              "items": [
+                {
+                  "type": "TextBlock"
+                }
+              ],
+              "selectAction": {
+                "type": "Action.OpenUrl",
+                "url": "https://adaptivecards.io/"
+              }
+            },
+            {
+              "type": "ColumnSet",
+              "horizontalAlignment": "Center",
+              "columns": [
+                {
+                  "type": "Column",
+                  "width": "stretch",
+                  "items": [
+                    {
+                      "type": "Icon",
+                      "name": "ChevronLeft",
+                      "color": "Accent",
+                      "size": "xSmall",
+                      "horizontalAlignment": "Right",
+                      "selectAction": {
+                        "type": "Action.ToggleVisibility",
+                        "targetElements": ["content2", "content3"]
+                      }
+                    }
+                  ],
+                  "verticalContentAlignment": "Center",
+                  "horizontalAlignment": "Center"
+                },
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "items": [
+                    {
+                      "type": "Icon",
+                      "name": "CircleSmall",
+                      "color": "Accent",
+                      "size": "Small",
+                      "horizontalAlignment": "Center",
+                      "selectAction": {
+                        "type": "Action.ToggleVisibility",
+                        "targetElements": ["content1", "content3"]
+                      }
+                    }
+                  ],
+                  "verticalContentAlignment": "Center"
+                },
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "items": [
+                    {
+                      "type": "Icon",
+                      "name": "CircleSmall",
+                      "color": "Accent",
+                      "size": "Small",
+                      "horizontalAlignment": "Center",
+                      "selectAction": {
+                        "type": "Action.ToggleVisibility",
+                        "targetElements": ["content2", "content3"]
+                      }
+                    }
+                  ],
+                  "verticalContentAlignment": "Center"
+                },
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "items": [
+                    {
+                      "type": "Icon",
+                      "name": "CircleSmall",
+                      "color": "Accent",
+                      "style": "Filled",
+                      "size": "Small",
+                      "horizontalAlignment": "Center"
+                    }
+                  ],
+                  "verticalContentAlignment": "Center"
+                },
+                {
+                  "type": "Column",
+                  "width": "stretch",
+                  "items": [
+                    {
+                      "type": "Icon",
+                      "name": "ChevronRight",
+                      "color": "Accent",
+                      "size": "xSmall",
+                      "horizontalAlignment": "Left",
+                      "selectAction": {
+                        "type": "Action.ToggleVisibility",
+                        "targetElements": ["content1", "content3"]
+                      }
+                    }
+                  ],
+                  "verticalContentAlignment": "Center"
+                }
+              ]
+            },
+            {
+              "text": "Productivity Mastery: How to Optimize Your Energy, Focus, and Motivation",
+              "weight": "Bolder",
+              "wrap": true,
+              "type": "TextBlock",
+              "horizontalAlignment": "Center"
+            },
+            {
+              "isSubtle": true,
+              "size": "Small",
+              "text": "Course · 30min",
+              "wrap": true,
+              "type": "TextBlock",
+              "spacing": "None",
+              "horizontalAlignment": "Center"
+            }
+          ],
+          "isVisible": false
+        }
+      ]
+    },
+    {
+      "actions": [
+        {
+          "url": "https://adaptivecards.io/",
+          "title": "Open Zenergy",
+          "type": "Action.OpenUrl"
+        },
+        {
+          "title": "Remind me later",
+          "iconUrl": "icon:Clock",
+          "type": "Action.Submit"
+        }
+      ],
+      "spacing": "Medium",
+      "type": "ActionSet"
+    }
+  ]
+}

--- a/shared/test-cards/teams-official-samples/project-dashboard.json
+++ b/shared/test-cards/teams-official-samples/project-dashboard.json
@@ -1,0 +1,785 @@
+{
+    "type": "AdaptiveCard",
+    "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.5",
+    "body": [
+        {
+            "type": "TextBlock",
+            "text": "Contoso Mobile App Redesign",
+            "wrap": true,
+            "size": "Large",
+            "weight": "Bolder"
+        },
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                        {
+                            "type": "Badge",
+                            "text": "In Progress",
+                            "style": "Informative",
+                            "appearance": "Tint",
+                            "icon": "ArrowSync",
+                            "size": "Large"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Due Mar 15, 2025",
+                            "wrap": true,
+                            "size": "Small",
+                            "isSubtle": true
+                        }
+                    ],
+                    "verticalContentAlignment": "Center",
+                    "targetWidth": "AtLeast:Narrow"
+                }
+            ]
+        },
+        {
+            "type": "TextBlock",
+            "text": "Due Mar 15, 2025",
+            "wrap": true,
+            "size": "Small",
+            "isSubtle": true,
+            "targetWidth": "VeryNarrow",
+            "spacing": "ExtraSmall"
+        },
+        {
+            "type": "Container",
+            "layouts": [
+                {
+                    "type": "Layout.AreaGrid",
+                    "targetWidth": "atLeast:Standard",
+                    "columns": [25, 25, 25],
+                    "areas": [
+                        { "name": "kpi1" },
+                        { "name": "kpi2", "column": 2 },
+                        { "name": "kpi3", "column": 3 },
+                        { "name": "kpi4", "column": 4 }
+                    ],
+                    "columnSpacing": "Small"
+                },
+                {
+                    "type": "Layout.AreaGrid",
+                    "targetWidth": "Narrow",
+                    "columns": [50],
+                    "areas": [
+                        { "name": "kpi1" },
+                        { "name": "kpi2", "column": 2 },
+                        { "name": "kpi3", "row": 2 },
+                        { "name": "kpi4", "column": 2, "row": 2 }
+                    ],
+                    "columnSpacing": "Small",
+                    "rowSpacing": "Small"
+                }
+            ],
+            "items": [
+                {
+                    "type": "Container",
+                    "grid.area": "kpi1",
+                    "style": "emphasis",
+                    "roundedCorners": true,
+                    "showBorder": true,
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Completion",
+                            "wrap": true,
+                            "size": "Small",
+                            "isSubtle": true
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "68%",
+                            "wrap": true,
+                            "size": "ExtraLarge",
+                            "weight": "Bolder",
+                            "color": "Good",
+                            "spacing": "ExtraSmall"
+                        }
+                    ]
+                },
+                {
+                    "type": "Container",
+                    "grid.area": "kpi2",
+                    "style": "emphasis",
+                    "roundedCorners": true,
+                    "showBorder": true,
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Tasks Done",
+                            "wrap": true,
+                            "size": "Small",
+                            "isSubtle": true
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "34 / 50",
+                            "wrap": true,
+                            "size": "ExtraLarge",
+                            "weight": "Bolder",
+                            "spacing": "ExtraSmall"
+                        }
+                    ]
+                },
+                {
+                    "type": "Container",
+                    "grid.area": "kpi3",
+                    "style": "emphasis",
+                    "roundedCorners": true,
+                    "showBorder": true,
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Open Bugs",
+                            "wrap": true,
+                            "size": "Small",
+                            "isSubtle": true
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "7",
+                            "wrap": true,
+                            "size": "ExtraLarge",
+                            "weight": "Bolder",
+                            "color": "Attention",
+                            "spacing": "ExtraSmall"
+                        }
+                    ]
+                },
+                {
+                    "type": "Container",
+                    "grid.area": "kpi4",
+                    "style": "emphasis",
+                    "roundedCorners": true,
+                    "showBorder": true,
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Days Left",
+                            "wrap": true,
+                            "size": "Small",
+                            "isSubtle": true
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "31",
+                            "wrap": true,
+                            "size": "ExtraLarge",
+                            "weight": "Bolder",
+                            "color": "Warning",
+                            "spacing": "ExtraSmall"
+                        }
+                    ]
+                }
+            ],
+            "spacing": "Medium",
+            "separator": true
+        },
+        {
+            "type": "Container",
+            "layouts": [
+                {
+                    "type": "Layout.AreaGrid",
+                    "targetWidth": "atLeast:Standard",
+                    "columns": [60],
+                    "areas": [
+                        { "name": "milestones" },
+                        { "name": "team", "column": 2 }
+                    ],
+                    "columnSpacing": "Default"
+                }
+            ],
+            "items": [
+                {
+                    "type": "Container",
+                    "grid.area": "milestones",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Milestones",
+                            "wrap": true,
+                            "weight": "Bolder",
+                            "size": "Small"
+                        },
+                        {
+                            "type": "ColumnSet",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "Icon",
+                                            "name": "CheckmarkCircle",
+                                            "size": "xSmall",
+                                            "style": "Filled",
+                                            "color": "Good"
+                                        }
+                                    ],
+                                    "verticalContentAlignment": "Center"
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Design review",
+                                            "wrap": true,
+                                            "size": "Small"
+                                        }
+                                    ],
+                                    "spacing": "Small"
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Jan 20",
+                                            "wrap": true,
+                                            "size": "Small",
+                                            "isSubtle": true
+                                        }
+                                    ],
+                                    "targetWidth": "AtLeast:Narrow"
+                                }
+                            ],
+                            "spacing": "Small"
+                        },
+                        {
+                            "type": "ColumnSet",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "Icon",
+                                            "name": "CheckmarkCircle",
+                                            "size": "xSmall",
+                                            "style": "Filled",
+                                            "color": "Good"
+                                        }
+                                    ],
+                                    "verticalContentAlignment": "Center"
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "API integration",
+                                            "wrap": true,
+                                            "size": "Small"
+                                        }
+                                    ],
+                                    "spacing": "Small"
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Feb 3",
+                                            "wrap": true,
+                                            "size": "Small",
+                                            "isSubtle": true
+                                        }
+                                    ],
+                                    "targetWidth": "AtLeast:Narrow"
+                                }
+                            ],
+                            "spacing": "ExtraSmall"
+                        },
+                        {
+                            "type": "ColumnSet",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "Icon",
+                                            "name": "ArrowSync",
+                                            "size": "xSmall",
+                                            "color": "Accent"
+                                        }
+                                    ],
+                                    "verticalContentAlignment": "Center"
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Beta testing",
+                                            "wrap": true,
+                                            "size": "Small",
+                                            "weight": "Bolder"
+                                        }
+                                    ],
+                                    "spacing": "Small"
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Feb 28",
+                                            "wrap": true,
+                                            "size": "Small",
+                                            "isSubtle": true
+                                        }
+                                    ],
+                                    "targetWidth": "AtLeast:Narrow"
+                                }
+                            ],
+                            "spacing": "ExtraSmall"
+                        },
+                        {
+                            "type": "ColumnSet",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "Icon",
+                                            "name": "Circle",
+                                            "size": "xSmall",
+                                            "color": "Default"
+                                        }
+                                    ],
+                                    "verticalContentAlignment": "Center"
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "GA release",
+                                            "wrap": true,
+                                            "size": "Small",
+                                            "isSubtle": true
+                                        }
+                                    ],
+                                    "spacing": "Small"
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Mar 15",
+                                            "wrap": true,
+                                            "size": "Small",
+                                            "isSubtle": true
+                                        }
+                                    ],
+                                    "targetWidth": "AtLeast:Narrow"
+                                }
+                            ],
+                            "spacing": "ExtraSmall"
+                        }
+                    ]
+                },
+                {
+                    "type": "Container",
+                    "grid.area": "team",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Team",
+                            "wrap": true,
+                            "weight": "Bolder",
+                            "size": "Small"
+                        },
+                        {
+                            "type": "ColumnSet",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "Image",
+                                            "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/insights/assets/avatar-requestor.png",
+                                            "width": "24px",
+                                            "height": "24px",
+                                            "style": "Person"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Alex Chen",
+                                            "wrap": true,
+                                            "size": "Small",
+                                            "weight": "Bolder"
+                                        },
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Project Lead",
+                                            "wrap": true,
+                                            "size": "Small",
+                                            "isSubtle": true,
+                                            "spacing": "None"
+                                        }
+                                    ],
+                                    "spacing": "Small"
+                                }
+                            ],
+                            "spacing": "Small"
+                        },
+                        {
+                            "type": "ColumnSet",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "Image",
+                                            "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/insights/assets/avatar-approver1.png",
+                                            "width": "24px",
+                                            "height": "24px",
+                                            "style": "Person"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Priya Sharma",
+                                            "wrap": true,
+                                            "size": "Small",
+                                            "weight": "Bolder"
+                                        },
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "UX Designer",
+                                            "wrap": true,
+                                            "size": "Small",
+                                            "isSubtle": true,
+                                            "spacing": "None"
+                                        }
+                                    ],
+                                    "spacing": "Small"
+                                }
+                            ],
+                            "spacing": "Small"
+                        },
+                        {
+                            "type": "ColumnSet",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "Image",
+                                            "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/insights/assets/avatar-approver2.png",
+                                            "width": "24px",
+                                            "height": "24px",
+                                            "style": "Person"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Marcus Johnson",
+                                            "wrap": true,
+                                            "size": "Small",
+                                            "weight": "Bolder"
+                                        },
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "iOS Developer",
+                                            "wrap": true,
+                                            "size": "Small",
+                                            "isSubtle": true,
+                                            "spacing": "None"
+                                        }
+                                    ],
+                                    "spacing": "Small"
+                                }
+                            ],
+                            "spacing": "Small"
+                        },
+                        {
+                            "type": "ColumnSet",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "Image",
+                                            "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/insights/assets/avatar-approver3.png",
+                                            "width": "24px",
+                                            "height": "24px",
+                                            "style": "Person"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Sara Kim",
+                                            "wrap": true,
+                                            "size": "Small",
+                                            "weight": "Bolder"
+                                        },
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Android Developer",
+                                            "wrap": true,
+                                            "size": "Small",
+                                            "isSubtle": true,
+                                            "spacing": "None"
+                                        }
+                                    ],
+                                    "spacing": "Small"
+                                }
+                            ],
+                            "spacing": "Small"
+                        }
+                    ]
+                }
+            ],
+            "spacing": "Medium",
+            "separator": true
+        },
+        {
+            "type": "Container",
+            "spacing": "Medium",
+            "separator": true,
+            "items": [
+                {
+                    "type": "TextBlock",
+                    "text": "Recent Activity",
+                    "wrap": true,
+                    "weight": "Bolder",
+                    "size": "Small"
+                },
+                {
+                    "type": "ColumnSet",
+                    "columns": [
+                        {
+                            "type": "Column",
+                            "width": "auto",
+                            "items": [
+                                {
+                                    "type": "Icon",
+                                    "name": "Checkmark",
+                                    "size": "xxSmall",
+                                    "color": "Good"
+                                }
+                            ],
+                            "verticalContentAlignment": "Center"
+                        },
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "items": [
+                                {
+                                    "type": "RichTextBlock",
+                                    "inlines": [
+                                        {
+                                            "type": "TextRun",
+                                            "text": "Alex ",
+                                            "weight": "Bolder",
+                                            "size": "Small"
+                                        },
+                                        {
+                                            "type": "TextRun",
+                                            "text": "merged PR #142 — Auth flow redesign",
+                                            "size": "Small"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "spacing": "Small"
+                        },
+                        {
+                            "type": "Column",
+                            "width": "auto",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "2h ago",
+                                    "wrap": true,
+                                    "size": "Small",
+                                    "isSubtle": true
+                                }
+                            ],
+                            "targetWidth": "AtLeast:Narrow"
+                        }
+                    ],
+                    "spacing": "Small"
+                },
+                {
+                    "type": "ColumnSet",
+                    "columns": [
+                        {
+                            "type": "Column",
+                            "width": "auto",
+                            "items": [
+                                {
+                                    "type": "Icon",
+                                    "name": "Bug",
+                                    "size": "xxSmall",
+                                    "color": "Attention"
+                                }
+                            ],
+                            "verticalContentAlignment": "Center"
+                        },
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "items": [
+                                {
+                                    "type": "RichTextBlock",
+                                    "inlines": [
+                                        {
+                                            "type": "TextRun",
+                                            "text": "Marcus ",
+                                            "weight": "Bolder",
+                                            "size": "Small"
+                                        },
+                                        {
+                                            "type": "TextRun",
+                                            "text": "opened bug #87 — Nav bar overlap on iPad",
+                                            "size": "Small"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "spacing": "Small"
+                        },
+                        {
+                            "type": "Column",
+                            "width": "auto",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "5h ago",
+                                    "wrap": true,
+                                    "size": "Small",
+                                    "isSubtle": true
+                                }
+                            ],
+                            "targetWidth": "AtLeast:Narrow"
+                        }
+                    ],
+                    "spacing": "ExtraSmall"
+                },
+                {
+                    "type": "ColumnSet",
+                    "columns": [
+                        {
+                            "type": "Column",
+                            "width": "auto",
+                            "items": [
+                                {
+                                    "type": "Icon",
+                                    "name": "Design",
+                                    "size": "xxSmall",
+                                    "color": "Accent"
+                                }
+                            ],
+                            "verticalContentAlignment": "Center"
+                        },
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "items": [
+                                {
+                                    "type": "RichTextBlock",
+                                    "inlines": [
+                                        {
+                                            "type": "TextRun",
+                                            "text": "Priya ",
+                                            "weight": "Bolder",
+                                            "size": "Small"
+                                        },
+                                        {
+                                            "type": "TextRun",
+                                            "text": "uploaded new mockups for Settings page",
+                                            "size": "Small"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "spacing": "Small"
+                        },
+                        {
+                            "type": "Column",
+                            "width": "auto",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "1d ago",
+                                    "wrap": true,
+                                    "size": "Small",
+                                    "isSubtle": true
+                                }
+                            ],
+                            "targetWidth": "AtLeast:Narrow"
+                        }
+                    ],
+                    "spacing": "ExtraSmall"
+                }
+            ]
+        },
+        {
+            "type": "ActionSet",
+            "spacing": "Medium",
+            "actions": [
+                {
+                    "type": "Action.OpenUrl",
+                    "title": "Open project",
+                    "url": "https://github.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples"
+                },
+                {
+                    "type": "Action.OpenUrl",
+                    "title": "View all tasks",
+                    "url": "https://github.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples"
+                }
+            ]
+        }
+    ]
+}

--- a/shared/test-cards/teams-official-samples/recipe.json
+++ b/shared/test-cards/teams-official-samples/recipe.json
@@ -1,0 +1,131 @@
+{
+  "type": "AdaptiveCard",
+  "speak": "Apricot-chile glazed chicken recipe",
+  "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Image",
+      "altText": "Image of Apricot-Chile Glazed Chicken",
+      "size": "Stretch",
+      "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/refs/heads/main/samples/recipe/assets/recipe_image.png",
+      "style": "RoundedCorners"
+    },
+    {
+      "type": "TextBlock",
+      "text": "Apricot-Chile Glazed Chicken",
+      "wrap": true,
+      "size": "Large",
+      "weight": "Bolder",
+      "color": "Default"
+    },
+    {
+      "type": "TextBlock",
+      "text": "15 min · 215 calories · 29g protein",
+      "wrap": true,
+      "spacing": "None",
+      "fontType": "Default",
+      "size": "Small",
+      "weight": "Default",
+      "isSubtle": true,
+      "color": "Default"
+    },
+    {
+      "type": "TextBlock",
+      "id": "truncatedText",
+      "text": "This sweet apricot-chile glazed broccoli recipe marries fruit and chiles to make this dish mouthwateringly special. Use organic jam in place of preserves for a smoother, prettier glaze if you are into spicy food, then this will be right up your alley.\n\nThe recipe calls for 1/4 cup of the chili sauce which gives the chicken quite a bite on the palate. But for all you heat lovers, it's definitely a good feel.",
+      "wrap": true,
+      "maxLines": 3
+    },
+    {
+      "type": "TextBlock",
+      "id": "fullText1",
+      "text": "This sweet apricot-chile glazed broccoli recipe marries fruit and chiles to make this dish mouthwateringly special. Use organic jam in place of preserves for a smoother, prettier glaze if you are into spicy food, then this will be right up your alley.",
+      "wrap": true,
+      "isVisible": false
+    },
+    {
+      "type": "TextBlock",
+      "id": "fullText2",
+      "text": "The recipe calls for 1/4 cup of the chili sauce which gives the chicken quite a bite on the palate. But for all you heat lovers, it's definitely a good feel.",
+      "wrap": true,
+      "isVisible": false
+    },
+    {
+      "type": "RichTextBlock",
+      "id": "showMore",
+      "targetWidth": "AtLeast:Narrow",
+      "inlines": [
+        {
+          "type": "TextRun",
+          "text": "Show more",
+          "selectAction": {
+            "type": "Action.ToggleVisibility",
+            "targetElements": [
+              "truncatedText",
+              "fullText1",
+              "fullText2",
+              "showMore",
+              "showLess"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "RichTextBlock",
+      "id": "showLess",
+      "targetWidth": "AtLeast:Narrow",
+      "inlines": [
+        {
+          "type": "TextRun",
+          "text": "Show less",
+          "selectAction": {
+            "type": "Action.ToggleVisibility",
+            "targetElements": [
+              "truncatedText",
+              "fullText1",
+              "fullText2",
+              "showMore",
+              "showLess"
+            ]
+          }
+        }
+      ],
+      "isVisible": false
+    },
+    {
+      "type": "ActionSet",
+      "targetWidth": "AtLeast:Narrow",
+      "actions": [
+        {
+          "type": "Action.OpenUrl",
+          "title": "View recipe",
+          "url": "https://www.tasteofhome.com/recipes/spicy-apricot-glazed-chicken/"
+        },
+        {
+          "type": "Action.Submit",
+          "title": "Add to cart",
+          "iconUrl": "icon:Cart"
+        }
+      ],
+      "spacing": "Medium"
+    },
+    {
+      "type": "ActionSet",
+      "targetWidth": "VeryNarrow",
+      "actions": [
+        {
+          "type": "Action.OpenUrl",
+          "title": "View recipe",
+          "url": "https://www.tasteofhome.com/recipes/spicy-apricot-glazed-chicken/"
+        },
+        {
+          "type": "Action.Submit",
+          "iconUrl": "icon:Cart"
+        }
+      ],
+      "spacing": "Medium"
+    }
+  ]
+}

--- a/shared/test-cards/teams-official-samples/simple-event.json
+++ b/shared/test-cards/teams-official-samples/simple-event.json
@@ -1,0 +1,246 @@
+{
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "bleed": true,
+      "backgroundImage": {
+        "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/simple-event/assets/eventHero.png",
+        "verticalAlignment": "Center"
+      },
+      "minHeight": "200px",
+      "verticalContentAlignment": "Bottom",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "MAY",
+          "wrap": true,
+          "color": "Light",
+          "size": "Large"
+        },
+        {
+          "type": "TextBlock",
+          "text": "31",
+          "wrap": true,
+          "color": "Light",
+          "size": "ExtraLarge",
+          "spacing": "None",
+          "weight": "Bolder"
+        }
+      ],
+      "targetWidth": "Standard",
+      "roundedCorners": false
+    },
+    {
+      "type": "Container",
+      "bleed": true,
+      "backgroundImage": {
+        "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/simple-event/assets/eventHero.png",
+        "verticalAlignment": "Center"
+      },
+      "minHeight": "200px",
+      "verticalContentAlignment": "Bottom",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "MAY",
+          "wrap": true,
+          "color": "Light",
+          "size": "Large"
+        },
+        {
+          "type": "TextBlock",
+          "text": "31",
+          "wrap": true,
+          "color": "Light",
+          "size": "ExtraLarge",
+          "spacing": "None",
+          "weight": "Bolder"
+        }
+      ],
+      "targetWidth": "Wide",
+      "roundedCorners": false
+    },
+    {
+      "type": "Container",
+      "bleed": true,
+      "backgroundImage": {
+        "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/simple-event/assets/eventHero.png"
+      },
+      "minHeight": "200px",
+      "verticalContentAlignment": "Bottom",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "8px"
+            },
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "MAY",
+                  "wrap": true,
+                  "color": "Light",
+                  "size": "Large"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "31",
+                  "wrap": true,
+                  "color": "Light",
+                  "size": "ExtraLarge",
+                  "spacing": "None",
+                  "weight": "Bolder"
+                }
+              ],
+              "spacing": "None"
+            }
+          ]
+        },
+        {
+          "type": "ColumnSet",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch"
+            }
+          ]
+        }
+      ],
+      "targetWidth": "Narrow",
+      "roundedCorners": true
+    },
+    {
+      "type": "Container",
+      "bleed": true,
+      "backgroundImage": {
+        "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/simple-event/assets/eventHero.png"
+      },
+      "minHeight": "200px",
+      "verticalContentAlignment": "Bottom",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "8px"
+            },
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "MAY",
+                  "wrap": true,
+                  "color": "Light",
+                  "size": "Large"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "31",
+                  "wrap": true,
+                  "color": "Light",
+                  "size": "ExtraLarge",
+                  "spacing": "None",
+                  "weight": "Bolder"
+                }
+              ],
+              "spacing": "None"
+            }
+          ]
+        },
+        {
+          "type": "ColumnSet",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch"
+            }
+          ]
+        }
+      ],
+      "targetWidth": "VeryNarrow",
+      "roundedCorners": true
+    },
+    {
+      "type": "TextBlock",
+      "text": "AI",
+      "wrap": true,
+      "size": "Small",
+      "weight": "Bolder",
+      "isSubtle": true
+    },
+    {
+      "type": "TextBlock",
+      "text": "AI Reality Check: Accessibility and Personalization ",
+      "wrap": true,
+      "weight": "Bolder",
+      "spacing": "None"
+    },
+    {
+      "type": "TextBlock",
+      "text": "Fri, Aug 23, 12:00 PM",
+      "wrap": true,
+      "size": "Small",
+      "weight": "Bolder"
+    },
+    {
+      "type": "TextBlock",
+      "text": "Online (Teams)",
+      "wrap": true,
+      "size": "Small",
+      "isSubtle": true,
+      "spacing": "None"
+    },
+    {
+      "type": "ActionSet",
+      "actions": [
+        {
+          "type": "Action.ShowCard",
+          "card": {
+            "type": "AdaptiveCard",
+            "body": [
+              {
+                "type": "Input.Text",
+                "id": "name",
+                "placeholder": "Enter your full name",
+                "label": "Name"
+              },
+              {
+                "type": "Input.Text",
+                "id": "email",
+                "placeholder": "Enter your email address",
+                "label": "Email address",
+                "isRequired": true,
+                "errorMessage": "An email is required"
+              },
+              {
+                "type": "ActionSet",
+                "actions": [
+                  {
+                    "type": "Action.Submit",
+                    "title": "Submit",
+                    "style": "positive"
+                  }
+                ]
+              }
+            ],
+            "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+            "version": "1.5"
+          },
+          "title": "Reserve a seat",
+          "style": "positive"
+        }
+      ]
+    }
+  ],
+  "$schema": "https://adaptivecards.io/schemas/adaptive-card.json"
+}

--- a/shared/test-cards/teams-official-samples/simple-time-off-request.json
+++ b/shared/test-cards/teams-official-samples/simple-time-off-request.json
@@ -1,0 +1,124 @@
+{
+    "type": "AdaptiveCard",
+    "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.5",
+    "body": [
+        {
+            "type": "TextBlock",
+            "text": "Time Off Request",
+            "wrap": true,
+            "size": "Large",
+            "weight": "Bolder"
+        },
+        {
+            "type": "Container",
+            "backgroundImage": {
+                "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/simple-time-off-request/assets/hero.png"
+            },
+            "minHeight": "140px",
+            "targetWidth": "Narrow",
+            "roundedCorners": true
+        },
+        {
+            "type": "Container",
+            "backgroundImage": {
+                "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/simple-time-off-request/assets/hero.png"
+            },
+            "minHeight": "180px",
+            "roundedCorners": true,
+            "items": [
+                {
+                    "type": "ColumnSet",
+                    "columns": [
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "verticalContentAlignment": "Top",
+                            "roundedCorners": true
+                        },
+                        {
+                            "type": "Column",
+                            "width": "auto",
+                            "backgroundImage": {
+                                "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/simple-time-off-request/assets/colorSpacer.png"
+                            },
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Take a Break",
+                                    "wrap": true,
+                                    "size": "ExtraLarge",
+                                    "weight": "Bolder",
+                                    "color": "Dark"
+                                }
+                            ],
+                            "roundedCorners": true,
+                            "spacing": "None"
+                        }
+                    ],
+                    "horizontalAlignment": "Right",
+                    "targetWidth": "AtLeast:Narrow",
+                    "spacing": "ExtraLarge"
+                }
+            ],
+            "targetWidth": "AtLeast:Standard"
+        },
+        {
+            "type": "Container",
+            "backgroundImage": {
+                "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/simple-time-off-request/assets/hero.png",
+                "horizontalAlignment": "Center"
+            },
+            "minHeight": "100px",
+            "targetWidth": "VeryNarrow",
+            "roundedCorners": true
+        },
+        {
+            "type": "Input.ChoiceSet",
+            "choices": [
+                {
+                    "title": "Vacation",
+                    "value": "Vacation"
+                },
+                {
+                    "title": "Sick leave",
+                    "value": "Sick Leave"
+                },
+                {
+                    "title": "Sick day",
+                    "value": "Sick day"
+                },
+                {
+                    "title": "Family medical leave",
+                    "value": "Family medical leave"
+                }
+            ],
+            "placeholder": "Enter your reason",
+            "label": "Reason for leave",
+            "value": "Vacation",
+            "isRequired": true,
+            "errorMessage": "Please enter a reason",
+            "id": "Reason",
+            "spacing": "Medium"
+        },
+        {
+            "type": "Input.Date",
+            "label": "Date",
+            "isRequired": true,
+            "errorMessage": "Please enter your date",
+            "id": "Date"
+        },
+        {
+            "type": "ActionSet",
+            "actions": [
+                {
+                    "type": "Action.Submit",
+                    "title": "Submit",
+                    "style": "positive",
+                    "tooltip": "Submit form"
+                }
+            ],
+            "spacing": "ExtraLarge"
+        }
+    ]
+}

--- a/shared/test-cards/teams-official-samples/standard-video.json
+++ b/shared/test-cards/teams-official-samples/standard-video.json
@@ -1,0 +1,109 @@
+{
+  "type": "AdaptiveCard",
+  "speak": "Web development bootcamp video",
+  "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Image",
+      "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Card-Samples/main/samples/standard-video/assets/video_image.png",
+      "altText": "Web Development Bootcamp Video",
+      "style": "RoundedCorners"
+    },
+    {
+      "type": "TextBlock",
+      "text": "Web Development Bootcamp",
+      "wrap": true,
+      "size": "Large",
+      "weight": "Bolder"
+    },
+    {
+      "type": "TextBlock",
+      "text": "HackLab Films",
+      "wrap": true,
+      "spacing": "Small",
+      "weight": "Bolder"
+    },
+    {
+      "type": "TextBlock",
+      "text": "24m · 17.1M views · 2 months ago",
+      "wrap": true,
+      "spacing": "None"
+    },
+    {
+      "type": "ActionSet",
+      "targetWidth": "AtLeast:Narrow",
+      "actions": [
+        {
+          "type": "Action.OpenUrl",
+          "title": "Open",
+          "url": "https://adaptivecards.io/"
+        },
+        {
+          "type": "Action.OpenUrl",
+          "title": "Add to calendar",
+          "url": "https://adaptivecards.io/",
+          "iconUrl": "icon:Calendar"
+        },
+        {
+          "type": "Action.OpenUrl",
+          "title": "Share in Teams",
+          "mode": "secondary",
+          "url": "https://adaptivecards.io/",
+          "iconUrl": "icon:PeopleTeam"
+        },
+        {
+          "type": "Action.OpenUrl",
+          "title": "Download",
+          "url": "https://adaptivecards.io/",
+          "mode": "secondary",
+          "iconUrl": "icon:ArrowDown"
+        },
+        {
+          "type": "Action.OpenUrl",
+          "title": "Copy link",
+          "mode": "secondary",
+          "url": "https://adaptivecards.io/",
+          "iconUrl": "icon:Link"
+        }
+      ]
+    },
+    {
+      "type": "ActionSet",
+      "targetWidth": "VeryNarrow",
+      "actions": [
+        {
+          "type": "Action.OpenUrl",
+          "title": "Open",
+          "url": "https://adaptivecards.io/"
+        },
+        {
+          "type": "Action.OpenUrl",
+          "iconUrl": "icon:Calendar",
+          "url": "https://adaptivecards.io/"
+        },
+        {
+          "type": "Action.OpenUrl",
+          "iconUrl": "icon:PeopleTeam",
+          "title": "Share in Teams",
+          "mode": "secondary",
+          "url": "https://adaptivecards.io/"
+        },
+        {
+          "type": "Action.OpenUrl",
+          "iconUrl": "icon:ArrowDown",
+          "title": "Download",
+          "url": "https://adaptivecards.io/",
+          "mode": "secondary"
+        },
+        {
+          "type": "Action.OpenUrl",
+          "iconUrl": "icon:Link",
+          "title": "Copy link",
+          "mode": "secondary",
+          "url": "https://adaptivecards.io/"
+        }
+      ]
+    }
+  ]
+}

--- a/shared/test-cards/teams-official-samples/team-standup-summary.json
+++ b/shared/test-cards/teams-official-samples/team-standup-summary.json
@@ -1,0 +1,454 @@
+{
+    "type": "AdaptiveCard",
+    "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.5",
+    "body": [
+        {
+            "type": "TextBlock",
+            "text": "Daily Standup Summary",
+            "wrap": true,
+            "size": "Large",
+            "weight": "Bolder"
+        },
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Design Systems Team",
+                            "wrap": true,
+                            "weight": "Bolder"
+                        }
+                    ],
+                    "verticalContentAlignment": "Center"
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "Badge",
+                            "text": "3 of 4 reported",
+                            "style": "Informative",
+                            "appearance": "Tint",
+                            "icon": "People"
+                        }
+                    ]
+                }
+            ],
+            "targetWidth": "AtLeast:Narrow"
+        },
+        {
+            "type": "Container",
+            "targetWidth": "VeryNarrow",
+            "items": [
+                {
+                    "type": "TextBlock",
+                    "text": "Design Systems Team",
+                    "wrap": true,
+                    "weight": "Bolder"
+                },
+                {
+                    "type": "Badge",
+                    "text": "3 of 4 reported",
+                    "style": "Informative",
+                    "appearance": "Tint",
+                    "icon": "People",
+                    "spacing": "ExtraSmall",
+                    "horizontalAlignment": "Left"
+                }
+            ]
+        },
+        {
+            "type": "TextBlock",
+            "text": "Wed, Feb 12, 2025 · 9:30 AM",
+            "wrap": true,
+            "size": "Small",
+            "isSubtle": true,
+            "spacing": "ExtraSmall"
+        },
+        {
+            "type": "Container",
+            "layouts": [
+                {
+                    "type": "Layout.AreaGrid",
+                    "targetWidth": "atLeast:Standard",
+                    "columns": [50],
+                    "areas": [
+                        { "name": "member1" },
+                        { "name": "member2", "column": 2 },
+                        { "name": "member3", "row": 2 },
+                        { "name": "member4", "column": 2, "row": 2 }
+                    ],
+                    "columnSpacing": "Default",
+                    "rowSpacing": "Default"
+                }
+            ],
+            "items": [
+                {
+                    "type": "Container",
+                    "grid.area": "member1",
+                    "style": "emphasis",
+                    "roundedCorners": true,
+                    "showBorder": true,
+                    "items": [
+                        {
+                            "type": "ColumnSet",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "Image",
+                                            "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/insights/assets/avatar-requestor.png",
+                                            "width": "32px",
+                                            "height": "32px",
+                                            "style": "Person"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Alex Chen",
+                                            "wrap": true,
+                                            "weight": "Bolder",
+                                            "size": "Small"
+                                        },
+                                        {
+                                            "type": "Badge",
+                                            "text": "On track",
+                                            "style": "Good",
+                                            "appearance": "Tint",
+                                            "icon": "CheckmarkCircle",
+                                            "size": "Medium"
+                                        }
+                                    ],
+                                    "spacing": "Small"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "**Yesterday:** Completed token migration for Button component",
+                            "wrap": true,
+                            "size": "Small",
+                            "spacing": "Small"
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "**Today:** Starting Dialog accessibility audit",
+                            "wrap": true,
+                            "size": "Small",
+                            "spacing": "ExtraSmall"
+                        }
+                    ]
+                },
+                {
+                    "type": "Container",
+                    "grid.area": "member2",
+                    "style": "emphasis",
+                    "roundedCorners": true,
+                    "showBorder": true,
+                    "items": [
+                        {
+                            "type": "ColumnSet",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "Image",
+                                            "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/insights/assets/avatar-approver1.png",
+                                            "width": "32px",
+                                            "height": "32px",
+                                            "style": "Person"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Priya Sharma",
+                                            "wrap": true,
+                                            "weight": "Bolder",
+                                            "size": "Small"
+                                        },
+                                        {
+                                            "type": "Badge",
+                                            "text": "Blocked",
+                                            "style": "Attention",
+                                            "appearance": "Tint",
+                                            "icon": "Warning",
+                                            "size": "Medium"
+                                        }
+                                    ],
+                                    "spacing": "Small"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "**Yesterday:** Worked on responsive grid component",
+                            "wrap": true,
+                            "size": "Small",
+                            "spacing": "Small"
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "**Blocker:** Waiting on design specs for breakpoints",
+                            "wrap": true,
+                            "size": "Small",
+                            "spacing": "ExtraSmall",
+                            "color": "Attention"
+                        }
+                    ]
+                },
+                {
+                    "type": "Container",
+                    "grid.area": "member3",
+                    "style": "emphasis",
+                    "roundedCorners": true,
+                    "showBorder": true,
+                    "items": [
+                        {
+                            "type": "ColumnSet",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "Image",
+                                            "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/insights/assets/avatar-approver2.png",
+                                            "width": "32px",
+                                            "height": "32px",
+                                            "style": "Person"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Marcus Johnson",
+                                            "wrap": true,
+                                            "weight": "Bolder",
+                                            "size": "Small"
+                                        },
+                                        {
+                                            "type": "Badge",
+                                            "text": "On track",
+                                            "style": "Good",
+                                            "appearance": "Tint",
+                                            "icon": "CheckmarkCircle",
+                                            "size": "Medium"
+                                        }
+                                    ],
+                                    "spacing": "Small"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "**Yesterday:** Fixed 3 a11y issues in DatePicker",
+                            "wrap": true,
+                            "size": "Small",
+                            "spacing": "Small"
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "**Today:** Writing unit tests for DatePicker fixes",
+                            "wrap": true,
+                            "size": "Small",
+                            "spacing": "ExtraSmall"
+                        }
+                    ]
+                },
+                {
+                    "type": "Container",
+                    "grid.area": "member4",
+                    "style": "emphasis",
+                    "roundedCorners": true,
+                    "showBorder": true,
+                    "items": [
+                        {
+                            "type": "ColumnSet",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "width": "auto",
+                                    "items": [
+                                        {
+                                            "type": "Image",
+                                            "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/insights/assets/avatar-approver3.png",
+                                            "width": "32px",
+                                            "height": "32px",
+                                            "style": "Person"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "Sara Kim",
+                                            "wrap": true,
+                                            "weight": "Bolder",
+                                            "size": "Small"
+                                        },
+                                        {
+                                            "type": "Badge",
+                                            "text": "Not reported",
+                                            "style": "Warning",
+                                            "appearance": "Tint",
+                                            "icon": "Clock",
+                                            "size": "Medium"
+                                        }
+                                    ],
+                                    "spacing": "Small"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "No status update submitted yet.",
+                            "wrap": true,
+                            "size": "Small",
+                            "isSubtle": true,
+                            "spacing": "Small"
+                        }
+                    ]
+                }
+            ],
+            "spacing": "Medium",
+            "separator": true
+        },
+        {
+            "type": "Container",
+            "style": "attention",
+            "roundedCorners": true,
+            "showBorder": true,
+            "spacing": "Medium",
+            "items": [
+                {
+                    "type": "ColumnSet",
+                    "columns": [
+                        {
+                            "type": "Column",
+                            "width": "auto",
+                            "items": [
+                                {
+                                    "type": "Icon",
+                                    "name": "Warning",
+                                    "size": "xSmall",
+                                    "color": "Attention"
+                                }
+                            ],
+                            "verticalContentAlignment": "Center"
+                        },
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "1 blocker needs attention",
+                                    "wrap": true,
+                                    "size": "Small",
+                                    "weight": "Bolder"
+                                }
+                            ],
+                            "spacing": "Small",
+                            "verticalContentAlignment": "Center"
+                        }
+                    ]
+                },
+                {
+                    "type": "TextBlock",
+                    "text": "Priya Sharma is blocked waiting on design specs for responsive breakpoints.",
+                    "wrap": true,
+                    "size": "Small",
+                    "spacing": "ExtraSmall"
+                }
+            ]
+        },
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Sprint 24 · Day 7 of 14",
+                            "wrap": true,
+                            "size": "Small",
+                            "isSubtle": true
+                        }
+                    ],
+                    "verticalContentAlignment": "Center"
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "12 tasks remaining",
+                            "wrap": true,
+                            "size": "Small",
+                            "isSubtle": true
+                        }
+                    ],
+                    "verticalContentAlignment": "Center",
+                    "targetWidth": "AtLeast:Narrow"
+                }
+            ],
+            "spacing": "Medium",
+            "separator": true
+        },
+        {
+            "type": "TextBlock",
+            "text": "12 tasks remaining",
+            "wrap": true,
+            "size": "Small",
+            "isSubtle": true,
+            "targetWidth": "VeryNarrow",
+            "spacing": "ExtraSmall"
+        },
+        {
+            "type": "ActionSet",
+            "spacing": "Medium",
+            "actions": [
+                {
+                    "type": "Action.OpenUrl",
+                    "title": "View sprint board",
+                    "url": "https://github.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples"
+                },
+                {
+                    "type": "Action.OpenUrl",
+                    "title": "Submit update",
+                    "url": "https://github.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples"
+                }
+            ]
+        }
+    ]
+}

--- a/shared/test-cards/teams-official-samples/time-off-request.json
+++ b/shared/test-cards/teams-official-samples/time-off-request.json
@@ -1,0 +1,870 @@
+{
+  "type": "AdaptiveCard",
+  "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "TextBlock",
+      "text": "Time off request",
+      "wrap": true,
+      "size": "Large",
+      "weight": "Bolder",
+      "spacing": "None"
+    },
+    {
+      "type": "Image",
+      "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/time-off-request/assets/hero-image-default.png",
+      "style": "RoundedCorners",
+      "targetWidth": "AtMost:Standard"
+    },
+    {
+      "type": "Image",
+      "targetWidth": "Wide",
+      "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/main/samples/time-off-request/assets/hero-wide.png",
+      "style": "RoundedCorners"
+    },
+    {
+      "type": "TextBlock",
+      "text": "Current balance",
+      "wrap": true,
+      "weight": "Bolder",
+      "color": "Accent",
+      "targetWidth": "AtLeast:Narrow"
+    },
+    {
+      "type": "Container",
+      "style": "accent",
+      "showBorder": true,
+      "roundedCorners": true,
+      "items": [
+        {
+          "type": "ColumnSet",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "24h",
+                  "wrap": true,
+                  "color": "Accent",
+                  "size": "ExtraLarge",
+                  "weight": "Bolder"
+                },
+                {
+                  "type": "ColumnSet",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "Icon",
+                          "name": "HeartPulse",
+                          "color": "Accent",
+                          "size": "xSmall"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "Sick Days",
+                          "wrap": true,
+                          "weight": "Bolder",
+                          "size": "Default"
+                        }
+                      ],
+                      "spacing": "ExtraSmall"
+                    }
+                  ],
+                  "spacing": "ExtraSmall"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "Accrued at eight hours per three months.",
+                  "wrap": true,
+                  "isSubtle": true,
+                  "size": "Small",
+                  "spacing": "ExtraSmall"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "12h",
+                  "wrap": true,
+                  "color": "Accent",
+                  "size": "ExtraLarge",
+                  "weight": "Bolder"
+                },
+                {
+                  "type": "ColumnSet",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "Icon",
+                          "name": "LeafOne",
+                          "color": "Accent",
+                          "size": "xSmall"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "Wellness",
+                          "wrap": true,
+                          "weight": "Bolder"
+                        }
+                      ],
+                      "spacing": "ExtraSmall"
+                    }
+                  ],
+                  "spacing": "ExtraSmall"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "One time 5 day affordance for the year",
+                  "wrap": true,
+                  "isSubtle": true,
+                  "size": "Small",
+                  "spacing": "ExtraSmall"
+                }
+              ],
+              "spacing": "ExtraLarge"
+            },
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "32h",
+                  "wrap": true,
+                  "color": "Accent",
+                  "size": "ExtraLarge",
+                  "weight": "Bolder"
+                },
+                {
+                  "type": "ColumnSet",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "Icon",
+                          "name": "Beach",
+                          "color": "Accent",
+                          "size": "xSmall"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "Paid time off",
+                          "wrap": true,
+                          "weight": "Bolder"
+                        }
+                      ],
+                      "spacing": "ExtraSmall"
+                    }
+                  ],
+                  "spacing": "ExtraSmall"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "Accrued at eight hours per one month.",
+                  "wrap": true,
+                  "isSubtle": true,
+                  "size": "Small",
+                  "spacing": "ExtraSmall"
+                }
+              ],
+              "spacing": "ExtraLarge"
+            }
+          ]
+        }
+      ],
+      "spacing": "ExtraSmall",
+      "targetWidth": "Wide",
+      "horizontalAlignment": "Center"
+    },
+    {
+      "type": "Container",
+      "style": "accent",
+      "showBorder": true,
+      "roundedCorners": true,
+      "items": [
+        {
+          "type": "ColumnSet",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "auto",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "24h",
+                  "wrap": true,
+                  "color": "Accent",
+                  "size": "ExtraLarge",
+                  "weight": "Bolder"
+                },
+                {
+                  "type": "ColumnSet",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "Icon",
+                          "name": "HeartPulse",
+                          "color": "Accent",
+                          "size": "xSmall"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "Sick Days",
+                          "wrap": true,
+                          "weight": "Bolder"
+                        }
+                      ],
+                      "spacing": "ExtraSmall"
+                    }
+                  ],
+                  "spacing": "ExtraSmall"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "Accrued at eight hours per three months.",
+                  "wrap": true,
+                  "isSubtle": true,
+                  "size": "Small",
+                  "spacing": "ExtraSmall"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "12h",
+                  "wrap": true,
+                  "color": "Accent",
+                  "size": "ExtraLarge",
+                  "weight": "Bolder"
+                },
+                {
+                  "type": "ColumnSet",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "Icon",
+                          "name": "LeafOne",
+                          "color": "Accent",
+                          "size": "xSmall"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "Wellness",
+                          "wrap": true,
+                          "weight": "Bolder"
+                        }
+                      ],
+                      "spacing": "ExtraSmall"
+                    }
+                  ],
+                  "spacing": "ExtraSmall"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "One time 5 day affordance for the year",
+                  "wrap": true,
+                  "isSubtle": true,
+                  "size": "Small",
+                  "spacing": "ExtraSmall"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "32h",
+                  "wrap": true,
+                  "color": "Accent",
+                  "size": "ExtraLarge",
+                  "weight": "Bolder"
+                },
+                {
+                  "type": "ColumnSet",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "Icon",
+                          "name": "Beach",
+                          "color": "Accent",
+                          "size": "xSmall"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "Paid time off",
+                          "wrap": true,
+                          "weight": "Bolder"
+                        }
+                      ],
+                      "spacing": "ExtraSmall"
+                    }
+                  ],
+                  "spacing": "ExtraSmall"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "Accrued at eight hours per one month.",
+                  "wrap": true,
+                  "isSubtle": true,
+                  "size": "Small",
+                  "spacing": "ExtraSmall"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "spacing": "ExtraSmall",
+      "targetWidth": "Standard"
+    },
+    {
+      "type": "Container",
+      "style": "accent",
+      "showBorder": true,
+      "roundedCorners": true,
+      "items": [
+        {
+          "type": "ColumnSet",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "Icon",
+                  "name": "HeartPulse",
+                  "color": "Accent",
+                  "horizontalAlignment": "Center",
+                  "size": "Small"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "24h",
+                  "wrap": true,
+                  "size": "Large",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "Sick days",
+                  "wrap": true,
+                  "weight": "Bolder",
+                  "spacing": "None",
+                  "size": "Small",
+                  "color": "Default"
+                }
+              ],
+              "horizontalAlignment": "Center"
+            },
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "Icon",
+                  "name": "LeafOne",
+                  "color": "Accent",
+                  "horizontalAlignment": "Center",
+                  "size": "Small"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "12h",
+                  "wrap": true,
+                  "size": "Large",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "Wellness",
+                  "wrap": true,
+                  "weight": "Bolder",
+                  "spacing": "None",
+                  "size": "Small",
+                  "color": "Default"
+                }
+              ],
+              "horizontalAlignment": "Center"
+            },
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "Icon",
+                  "horizontalAlignment": "Center",
+                  "name": "Beach",
+                  "color": "Accent",
+                  "size": "Small"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "32h",
+                  "wrap": true,
+                  "color": "Accent",
+                  "size": "Large",
+                  "weight": "Bolder",
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "Paid time off",
+                  "wrap": true,
+                  "weight": "Bolder",
+                  "spacing": "None",
+                  "size": "Small",
+                  "color": "Default"
+                }
+              ],
+              "horizontalAlignment": "Center"
+            }
+          ]
+        }
+      ],
+      "spacing": "ExtraSmall",
+      "targetWidth": "Narrow",
+      "horizontalAlignment": "Center"
+    },
+    {
+      "type": "ColumnSet",
+      "columns": [
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "RichTextBlock",
+              "inlines": [
+                {
+                  "type": "TextRun",
+                  "text": "View current balance",
+                  "selectAction": {
+                    "type": "Action.ToggleVisibility",
+                    "targetElements": [
+                      "vNarrowBalance",
+                      "balanceDown",
+                      "balanceUp"
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "Icon",
+              "name": "ChevronDown",
+              "size": "xxSmall",
+              "selectAction": {
+                "type": "Action.ToggleVisibility",
+                "targetElements": ["vNarrowBalance", "balanceDown", "balanceUp"]
+              },
+              "color": "Accent",
+              "id": "balanceDown"
+            },
+            {
+              "type": "Icon",
+              "isVisible": false,
+              "id": "balanceUp",
+              "name": "chevronUp",
+              "size": "xxSmall",
+              "color": "Accent",
+              "selectAction": {
+                "type": "Action.ToggleVisibility",
+                "targetElements": ["vNarrowBalance", "balanceDown", "balanceUp"]
+              }
+            }
+          ],
+          "verticalContentAlignment": "Bottom",
+          "spacing": "ExtraSmall"
+        }
+      ],
+      "targetWidth": "VeryNarrow"
+    },
+    {
+      "type": "Container",
+      "style": "accent",
+      "bleed": true,
+      "items": [
+        {
+          "type": "ColumnSet",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "40px",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "24h",
+                  "wrap": true,
+                  "size": "Large",
+                  "weight": "Bolder",
+                  "color": "Accent"
+                }
+              ],
+              "verticalContentAlignment": "Center"
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "items": [
+                {
+                  "type": "Icon",
+                  "color": "Accent",
+                  "name": "HeartPulse",
+                  "size": "xSmall"
+                }
+              ],
+              "verticalContentAlignment": "Center",
+              "spacing": "Small"
+            },
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "Sick days",
+                  "wrap": true,
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "color": "Default"
+                }
+              ],
+              "verticalContentAlignment": "Center",
+              "spacing": "ExtraSmall"
+            }
+          ],
+          "horizontalAlignment": "Left"
+        },
+        {
+          "type": "ColumnSet",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "40px",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "12h",
+                  "wrap": true,
+                  "weight": "Bolder",
+                  "color": "Accent",
+                  "size": "Large"
+                }
+              ],
+              "verticalContentAlignment": "Center"
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "items": [
+                {
+                  "type": "Icon",
+                  "color": "Accent",
+                  "name": "LeafOne",
+                  "size": "xSmall"
+                }
+              ],
+              "verticalContentAlignment": "Center",
+              "spacing": "Small"
+            },
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "Wellness",
+                  "wrap": true,
+                  "size": "Small",
+                  "weight": "Bolder",
+                  "color": "Default"
+                }
+              ],
+              "verticalContentAlignment": "Center",
+              "spacing": "ExtraSmall"
+            }
+          ],
+          "spacing": "ExtraSmall"
+        },
+        {
+          "type": "ColumnSet",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "40px",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "32h",
+                  "wrap": true,
+                  "weight": "Bolder",
+                  "color": "Accent",
+                  "size": "Large"
+                }
+              ],
+              "verticalContentAlignment": "Center"
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "items": [
+                {
+                  "type": "Icon",
+                  "color": "Accent",
+                  "name": "Beach",
+                  "size": "xSmall"
+                }
+              ],
+              "verticalContentAlignment": "Center",
+              "spacing": "Small"
+            },
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "Paid time off",
+                  "wrap": true,
+                  "size": "Small",
+                  "weight": "Bolder",
+                  "color": "Default"
+                }
+              ],
+              "verticalContentAlignment": "Center",
+              "spacing": "ExtraSmall"
+            }
+          ],
+          "spacing": "ExtraSmall"
+        }
+      ],
+      "spacing": "Small",
+      "isVisible": false,
+      "id": "vNarrowBalance",
+      "targetWidth": "VeryNarrow"
+    },
+    {
+      "type": "Input.ChoiceSet",
+      "label": "Reason for leave",
+      "choices": [
+        {
+          "title": "Vacation",
+          "value": "Vacation"
+        },
+        {
+          "title": "Sick Day",
+          "value": "Sick Day"
+        },
+        {
+          "title": "Sick Leave",
+          "value": "Sick Leave"
+        },
+        {
+          "title": "Other",
+          "value": "Other"
+        }
+      ],
+      "value": "Vacation",
+      "id": "leave_reason",
+      "spacing": "Medium"
+    },
+    {
+      "type": "Input.Toggle",
+      "title": "All day (8hrs)",
+      "id": "all_day",
+      "spacing": "Small"
+    },
+    {
+      "type": "Container",
+      "layouts": [
+        {
+          "type": "Layout.Flow",
+          "verticalItemsAlignment": "Bottom",
+          "minItemWidth": "0px",
+          "itemFit": "Fill"
+        }
+      ],
+      "items": [
+        {
+          "type": "Input.Date",
+          "label": "Date",
+          "id": "date",
+          "isRequired": true,
+          "errorMessage": "Date is required"
+        }
+      ]
+    },
+    {
+      "type": "ColumnSet",
+      "columns": [
+        {
+          "type": "Column",
+          "width": "stretch"
+        },
+        {
+          "type": "Column",
+          "width": "stretch",
+          "spacing": "Small",
+          "verticalContentAlignment": "Bottom"
+        }
+      ]
+    },
+    {
+      "type": "Input.Number",
+      "label": "Estimated days off",
+      "placeholder": "Select how many days",
+      "id": "days_off",
+      "spacing": "Medium"
+    },
+    {
+      "columns": [
+        {
+          "items": [
+            {
+              "inlines": [
+                {
+                  "selectAction": {
+                    "targetElements": ["comments", "chevronUp", "chevronDown"],
+                    "type": "Action.ToggleVisibility"
+                  },
+                  "text": "Add comments",
+                  "type": "TextRun"
+                }
+              ],
+              "targetWidth": "AtLeast:Narrow",
+              "type": "RichTextBlock"
+            }
+          ],
+          "type": "Column",
+          "verticalContentAlignment": "Center",
+          "width": "auto"
+        },
+        {
+          "items": [
+            {
+              "color": "Accent",
+              "id": "chevronDown",
+              "name": "ChevronDown",
+              "size": "xxSmall",
+              "type": "Icon"
+            },
+            {
+              "color": "Accent",
+              "id": "chevronUp",
+              "isVisible": false,
+              "name": "ChevronUp",
+              "size": "xxSmall",
+              "spacing": "None",
+              "type": "Icon"
+            }
+          ],
+          "selectAction": {
+            "targetElements": ["comments", "chevronUp", "chevronDown"],
+            "type": "Action.ToggleVisibility"
+          },
+          "spacing": "Small",
+          "type": "Column",
+          "verticalContentAlignment": "Center",
+          "width": "auto"
+        }
+      ],
+      "spacing": "Medium",
+      "type": "ColumnSet"
+    },
+    {
+      "type": "Input.Text",
+      "placeholder": "Enter any comments",
+      "id": "comments",
+      "isVisible": false,
+      "isMultiline": true
+    },
+    {
+      "type": "ActionSet",
+      "actions": [
+        {
+          "type": "Action.Submit",
+          "title": "Submit",
+          "style": "positive"
+        }
+      ],
+      "separator": true,
+      "spacing": "ExtraLarge"
+    }
+  ]
+}

--- a/shared/test-cards/teams-official-samples/work-item.json
+++ b/shared/test-cards/teams-official-samples/work-item.json
@@ -1,0 +1,219 @@
+{
+  "type": "AdaptiveCard",
+  "speak": "Bug 2837, icons not rendering in dark mode",
+  "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "ColumnSet",
+      "columns": [
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "Image",
+              "url": "https://raw.githubusercontent.com/OfficeDev/Microsoft-Teams-Card-Samples/main/samples/work_item/assets/thumb_image.png",
+              "width": "56px",
+              "height": "56px",
+              "altText": "Logo",
+              "style": "RoundedCorners"
+            }
+          ]
+        },
+        {
+          "type": "Column",
+          "width": "stretch",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "Bug 2837 - Icons not rendering in dark mode",
+              "wrap": true,
+              "weight": "Bolder"
+            },
+            {
+              "type": "ColumnSet",
+              "targetWidth": "AtLeast:Standard",
+              "columns": [
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "items": [
+                    {
+                      "type": "Icon",
+                      "name": "CircleSmall",
+                      "color": "Attention",
+                      "style": "Filled",
+                      "size": "Small"
+                    }
+                  ],
+                  "horizontalAlignment": "Center",
+                  "verticalContentAlignment": "Center"
+                },
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "items": [
+                    {
+                      "type": "TextBlock",
+                      "text": "Blocked",
+                      "wrap": true
+                    }
+                  ],
+                  "spacing": "None",
+                  "verticalContentAlignment": "Center"
+                },
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "items": [
+                    {
+                      "type": "TextBlock",
+                      "text": "|",
+                      "wrap": true
+                    }
+                  ],
+                  "spacing": "Small",
+                  "verticalContentAlignment": "Center"
+                },
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "items": [
+                    {
+                      "type": "TextBlock",
+                      "text": "Hugo Gonzalez",
+                      "wrap": true
+                    }
+                  ],
+                  "spacing": "Small",
+                  "verticalContentAlignment": "Center"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ColumnSet",
+      "targetWidth": "Narrow",
+      "columns": [
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "Icon",
+              "name": "CircleSmall",
+              "color": "Attention",
+              "style": "Filled",
+              "size": "Small"
+            }
+          ],
+          "horizontalAlignment": "Center",
+          "verticalContentAlignment": "Center"
+        },
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "Blocked",
+              "wrap": true
+            }
+          ],
+          "spacing": "None",
+          "verticalContentAlignment": "Center"
+        },
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "|",
+              "wrap": true
+            }
+          ],
+          "spacing": "Small",
+          "verticalContentAlignment": "Center"
+        },
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "Hugo Gonzalez",
+              "wrap": true
+            }
+          ],
+          "spacing": "Small",
+          "verticalContentAlignment": "Center"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "targetWidth": "VeryNarrow",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "auto",
+              "items": [
+                {
+                  "type": "Icon",
+                  "name": "CircleSmall",
+                  "color": "Attention",
+                  "style": "Filled",
+                  "size": "Small"
+                }
+              ],
+              "horizontalAlignment": "Center",
+              "verticalContentAlignment": "Center"
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "Blocked",
+                  "wrap": true
+                }
+              ],
+              "spacing": "None",
+              "verticalContentAlignment": "Center"
+            }
+          ]
+        },
+        {
+          "type": "TextBlock",
+          "text": "Hugo Gonzalez",
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "ActionSet",
+      "actions": [
+        {
+          "type": "Action.OpenUrl",
+          "title": "Open",
+          "url": "https://adaptivecards.io/"
+        },
+        {
+          "type": "Action.Submit",
+          "title": "Follow",
+          "iconUrl": "icon:Eye"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Integrates all 19 card samples from [OfficeDev/Microsoft-Teams-Adaptive-Card-Samples](https://github.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples) into the test card gallery
- 17 cards from the main repo + 2 responsive layout cards from [PR #39](https://github.com/OfficeDev/Microsoft-Teams-Adaptive-Card-Samples/pull/39)
- Cards placed in `shared/test-cards/teams-official-samples/` with a new "Teams Official" category on both platforms
- All cards are Adaptive Card v1.5 with responsive layouts (`targetWidth`, `Layout.AreaGrid`), `Badge`, `Icon`, and other advanced features

### Cards added
account, author-highlight-video, book-a-room, cafe-menu, communication, course-video, editorial, expense-report, insights, issue, list, project-dashboard, recipe, simple-event, simple-time-off-request, standard-video, team-standup-summary, time-off-request, work-item

### Changes
- **`shared/test-cards/teams-official-samples/`** — 19 new JSON card files
- **Android `CardGalleryScreen.kt`** — `TEAMS_OFFICIAL` enum + 19 card definitions + description
- **iOS `CardGalleryView.swift`** — `teamsOfficialSamples` in `CardCategory`/`CardSection` enums, subdirectory load call, summary pill

No build config changes needed — Android asset dirs and iOS dynamic discovery handle the new subdirectory automatically.

## Test plan
- [x] All 19 JSON files validate as proper Adaptive Cards (v1.5)
- [x] Android `./gradlew :sample-app:assembleDebug` — BUILD SUCCESSFUL
- [x] Android `./gradlew test` — all tests pass
- [x] iOS `swift build` — Build complete
- [x] iOS `swift test` — 232 tests, 0 failures
- [x] iOS SampleApp `xcodebuild build` — BUILD SUCCEEDED