### PR TITLE
fix(ios,android): audit fixes — state preservation & ActionDelegate parity

### DIFF
--- a/android/ac-rendering/src/main/kotlin/com/microsoft/adaptivecards/rendering/viewmodel/CardViewModel.kt
+++ b/android/ac-rendering/src/main/kotlin/com/microsoft/adaptivecards/rendering/viewmodel/CardViewModel.kt
@@ -330,8 +330,13 @@ class CardViewModel : ViewModel() {
     fun refreshData(newData: Map<String, Any?>) {
         val template = storedTemplate ?: return
         val savedInputs = inputValues.toMap()
+        val savedVisibility = visibilityState.toMap()
+        val savedShowCards = showCardState.toMap()
         parseCard(template, newData)
+        // Restore user state after re-parse
         inputValues.putAll(savedInputs)
+        visibilityState.putAll(savedVisibility)
+        showCardState.putAll(savedShowCards)
     }
 
     /**

--- a/ios/Sources/ACActions/ActionDelegate.swift
+++ b/ios/Sources/ACActions/ActionDelegate.swift
@@ -11,6 +11,12 @@ public protocol ActionDelegate: AnyObject {
 
     /// Called when an Action.Execute is triggered
     func onExecute(verb: String?, data: [String: Any], actionId: String?)
+
+    /// Called when an Action.ShowCard is triggered
+    func onShowCard(actionId: String?, isExpanded: Bool)
+
+    /// Called when an Action.ToggleVisibility is triggered
+    func onToggleVisibility(targetElementIds: [String])
 }
 
 /// Default implementation providing empty handlers
@@ -25,5 +31,13 @@ public extension ActionDelegate {
 
     func onExecute(verb: String?, data: [String: Any], actionId: String?) {
         print("Execute action triggered with verb: \(verb ?? "nil"), data: \(data)")
+    }
+
+    func onShowCard(actionId: String?, isExpanded: Bool) {
+        // Default: no-op (card expansion handled internally by CardViewModel)
+    }
+
+    func onToggleVisibility(targetElementIds: [String]) {
+        // Default: no-op (visibility toggling handled internally by CardViewModel)
     }
 }

--- a/ios/Sources/ACRendering/ViewModel/CardViewModel.swift
+++ b/ios/Sources/ACRendering/ViewModel/CardViewModel.swift
@@ -9,6 +9,8 @@ public class CardViewModel: ObservableObject {
     @Published public var visibility: [String: Bool] = [:]
     @Published public var showCards: [String: Bool] = [:]
     @Published public var parsingError: Error?
+    /// Incremented each time a new parsing error occurs, used for change detection
+    @Published public var parsingErrorId: Int = 0
 
     private let parser: CardParser
     private let templateEngine: TemplateEngine
@@ -26,7 +28,7 @@ public class CardViewModel: ObservableObject {
     /// - Parameters:
     ///   - json: The card JSON string (may contain `${expression}` template syntax)
     ///   - templateData: Optional data context for template expansion
-    public func parseCard(json: String, templateData: [String: Any]? = nil) {
+    public func parseCard(json: String, templateData: [String: Any]? = nil, completion: (() -> Void)? = nil) {
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self = self else { return }
 
@@ -49,11 +51,14 @@ public class CardViewModel: ObservableObject {
                     self.parsingError = nil
                     self.initializeVisibility(for: parsedCard)
                     self.initializeInputValues(for: parsedCard)
+                    completion?()
                 }
             } catch {
                 DispatchQueue.main.async {
                     self.parsingError = error
+                    self.parsingErrorId += 1
                     print("Failed to parse card: \(error)")
+                    completion?()
                 }
             }
         }
@@ -193,13 +198,16 @@ public class CardViewModel: ObservableObject {
     public func refreshData(_ newData: [String: Any]) {
         guard let template = storedTemplate else { return }
         let savedInputs = inputValues
-        parseCard(json: template, templateData: newData)
-        // Restore user-entered input values after re-parse completes
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+        let savedVisibility = visibility
+        let savedShowCards = showCards
+        parseCard(json: template, templateData: newData) { [weak self] in
             guard let self = self else { return }
+            // Restore user-entered state after re-parse completes
             for (key, value) in savedInputs {
                 self.inputValues[key] = value
             }
+            self.visibility.merge(savedVisibility) { _, kept in kept }
+            self.showCards.merge(savedShowCards) { _, kept in kept }
         }
     }
 

--- a/ios/Sources/ACRendering/Views/AdaptiveCardView.swift
+++ b/ios/Sources/ACRendering/Views/AdaptiveCardView.swift
@@ -54,12 +54,15 @@ public struct AdaptiveCardView: View {
             .onAppear {
                 viewModel.parseCard(json: cardJson, templateData: templateData)
             }
+            .onChange(of: cardJson) { newJson in
+                viewModel.parseCard(json: newJson, templateData: templateData)
+            }
             .onChange(of: viewModel.card) { card in
                 if let card = card {
                     onCardParsed?(card)
                 }
             }
-            .onChange(of: viewModel.parsingError?.localizedDescription) { errorDesc in
+            .onChange(of: viewModel.parsingErrorId) { _ in
                 if let error = viewModel.parsingError {
                     onCardParseError?(error)
                 }


### PR DESCRIPTION
## Summary

- **refreshData() state preservation** (iOS + Android): Now saves and restores `visibility` and `showCard` state during template re-expansion, not just input values. Previously toggled visibility and expanded show-cards were lost on data refresh.
- **iOS refreshData() race condition**: Replaced hardcoded 0.1s `DispatchQueue.main.asyncAfter` delay with a deterministic `completion` handler on `parseCard()`.
- **iOS AdaptiveCardView re-parse**: Added `.onChange(of: cardJson)` so the view re-parses when the parent changes the JSON binding at runtime.
- **iOS error tracking**: Replaced fragile `.onChange(of: parsingError?.localizedDescription)` with a `parsingErrorId` counter since `Error` is not `Equatable`.
- **iOS ActionDelegate parity**: Added `onShowCard(actionId:isExpanded:)` and `onToggleVisibility(targetElementIds:)` with default no-op implementations, matching Android's ActionDelegate surface.

## Test plan
- [x] iOS `swift build` passes
- [x] Android `assembleDebug` passes
- [x] SwiftLint clean (0 violations)
- [x] iOS sample app launches on iPhone 16e simulator
- [x] Android sample app launches on emulator