### PR TITLE
fix(android): resolve 4 crash-causing bugs in card rendering and navigation

### DIFF
--- a/android/ac-core/src/main/kotlin/com/microsoft/adaptivecards/core/models/CardAction.kt
+++ b/android/ac-core/src/main/kotlin/com/microsoft/adaptivecards/core/models/CardAction.kt
@@ -1,9 +1,18 @@
 package com.microsoft.adaptivecards.core.models
 
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 @Serializable
 sealed interface CardAction {
@@ -102,11 +111,49 @@ data class ActionToggleVisibility(
     val targetElements: List<TargetElement>
 ) : CardAction
 
-@Serializable
+@Serializable(with = TargetElementSerializer::class)
 data class TargetElement(
     val elementId: String,
     val isVisible: Boolean? = null
 )
+
+/**
+ * Per the Adaptive Card spec, targetElements entries can be either:
+ * - A string: just the element ID (e.g., "myElement")
+ * - An object: { "elementId": "myElement", "isVisible": true }
+ */
+object TargetElementSerializer : KSerializer<TargetElement> {
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("TargetElement")
+
+    override fun deserialize(decoder: Decoder): TargetElement {
+        val jsonDecoder = decoder as JsonDecoder
+        val element = jsonDecoder.decodeJsonElement()
+        return when (element) {
+            is JsonPrimitive -> TargetElement(elementId = element.content)
+            else -> {
+                val obj = element.jsonObject
+                TargetElement(
+                    elementId = obj["elementId"]?.jsonPrimitive?.content ?: "",
+                    isVisible = obj["isVisible"]?.jsonPrimitive?.content?.toBooleanStrictOrNull()
+                )
+            }
+        }
+    }
+
+    override fun serialize(encoder: Encoder, value: TargetElement) {
+        val jsonEncoder = encoder as kotlinx.serialization.json.JsonEncoder
+        if (value.isVisible == null) {
+            jsonEncoder.encodeJsonElement(JsonPrimitive(value.elementId))
+        } else {
+            jsonEncoder.encodeJsonElement(
+                kotlinx.serialization.json.buildJsonObject {
+                    put("elementId", JsonPrimitive(value.elementId))
+                    put("isVisible", JsonPrimitive(value.isVisible))
+                }
+            )
+        }
+    }
+}
 
 @Serializable
 @SerialName("Action.Popover")

--- a/android/ac-inputs/src/main/kotlin/com/microsoft/adaptivecards/inputs/composables/RatingInputView.kt
+++ b/android/ac-inputs/src/main/kotlin/com/microsoft/adaptivecards/inputs/composables/RatingInputView.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.StarBorder
-import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.material3.ripple
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -115,7 +115,7 @@ fun RatingInputView(
                         .size(starSize)
                         .clickable(
                             interactionSource = interactionSource,
-                            indication = rememberRipple(bounded = false, radius = starSize / 2),
+                            indication = ripple(bounded = false, radius = starSize / 2),
                             role = Role.RadioButton,
                             onClickLabel = "Rate $i stars"
                         ) {

--- a/android/ac-rendering/src/main/kotlin/com/microsoft/adaptivecards/rendering/composables/CarouselView.kt
+++ b/android/ac-rendering/src/main/kotlin/com/microsoft/adaptivecards/rendering/composables/CarouselView.kt
@@ -27,7 +27,6 @@ import kotlinx.coroutines.launch
  * Accessibility: Announces current page and total pages, supports swipe gestures
  * Responsive: Adapts padding and card size for tablets
  */
-@OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
 @Composable
 fun CarouselView(
     element: Carousel,

--- a/android/ac-rendering/src/main/kotlin/com/microsoft/adaptivecards/rendering/composables/TextBlockView.kt
+++ b/android/ac-rendering/src/main/kotlin/com/microsoft/adaptivecards/rendering/composables/TextBlockView.kt
@@ -66,7 +66,7 @@ fun TextBlockView(
         null -> TextAlign.Start
     }
     
-    val maxLines = element.maxLines ?: if (element.wrap == true) Int.MAX_VALUE else 1
+    val maxLines = (element.maxLines ?: if (element.wrap == true) Int.MAX_VALUE else 1).coerceAtLeast(1)
     val overflow = if (element.wrap == true) TextOverflow.Visible else TextOverflow.Ellipsis
     
     // Check if text contains markdown

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "2.0.21"
-compose-bom = "2024.01.00"
+compose-bom = "2024.10.01"
 compose-compiler = "2.0.21"
 agp = "8.2.0"
 kotlinx-serialization = "1.6.2"

--- a/android/sample-app/build.gradle.kts
+++ b/android/sample-app/build.gradle.kts
@@ -73,7 +73,7 @@ dependencies {
     implementation(project(":ac-host-config"))
 
     // Jetpack Compose
-    val composeBom = platform("androidx.compose:compose-bom:2024.01.00")
+    val composeBom = platform("androidx.compose:compose-bom:2024.10.01")
     implementation(composeBom)
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")

--- a/android/sample-app/src/main/kotlin/com/microsoft/adaptivecards/sample/CardGalleryScreen.kt
+++ b/android/sample-app/src/main/kotlin/com/microsoft/adaptivecards/sample/CardGalleryScreen.kt
@@ -1,6 +1,7 @@
 package com.microsoft.adaptivecards.sample
 
 import android.content.Context
+import android.net.Uri
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -85,7 +86,7 @@ fun CardGalleryScreen(navController: NavController) {
             ) {
                 items(filteredCards, key = { it.filename }) { card ->
                     CardItem(card) {
-                        navController.navigate("card_detail/${card.filename}")
+                        navController.navigate("card_detail/${Uri.encode(card.filename)}")
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- **Compose BOM version mismatch** — upgraded from `2024.01.00` to `2024.10.01` across all modules to fix `NoSuchMethodError` crash in `CarouselView` when `HorizontalPager` API signature changed between BOM versions
- **Navigation crash on subfolder cards** — URL-encode card filenames containing `/` (e.g. `teams-official-samples/video.json`) before passing to `NavController.navigate()`, fixing `IllegalArgumentException: Navigation destination not found`
- **TextBlock maxLines=0 crash** — coerce `maxLines` to `>= 1` since Compose `Text` throws `IllegalArgumentException` when `maxLines` is 0
- **TargetElement deserialization crash** — added custom `TargetElementSerializer` to handle both string (`"elementId"`) and object (`{"elementId": "...", "isVisible": true}`) formats per the Adaptive Card spec, fixing `JsonDecodingException`
- Replaced deprecated `rememberRipple` with Material3 `ripple()` API

## Test plan

- [x] Built and installed on Google Pixel 10 emulator (API 36)
- [x] Rapid-scrolled through all 152 cards — zero crashes
- [x] Tapped Carousel Scenario Timer card — renders with HorizontalPager + page indicators
- [x] Tapped Expense Report card (subfolder path `official-samples/`) — navigates correctly
- [x] Verified logcat: 0 FATAL EXCEPTION, 0 JsonDecodingException, 0 ANR