### PR TITLE
fix(android): implement targetWidth responsive filtering

### DIFF
--- a/android/ac-core/src/main/kotlin/com/microsoft/adaptivecards/core/models/CardElement.kt
+++ b/android/ac-core/src/main/kotlin/com/microsoft/adaptivecards/core/models/CardElement.kt
@@ -201,7 +201,8 @@ data class ActionSet(
     override val requires: Map<String, String>? = null,
     override val fallback: JsonElement? = null,
     val actions: List<CardAction>,
-    val mode: ActionSetMode? = null
+    val mode: ActionSetMode? = null,
+    val targetWidth: String? = null
 ) : CardElement
 
 @Serializable

--- a/android/ac-core/src/main/kotlin/com/microsoft/adaptivecards/core/models/TargetWidth.kt
+++ b/android/ac-core/src/main/kotlin/com/microsoft/adaptivecards/core/models/TargetWidth.kt
@@ -1,0 +1,83 @@
+package com.microsoft.adaptivecards.core.models
+
+/**
+ * Width categories for responsive targetWidth filtering per Adaptive Cards spec.
+ *
+ * Breakpoints (in dp):
+ * - VeryNarrow: < 300
+ * - Narrow: 300–499
+ * - Standard: 500–699
+ * - Wide: ≥ 700
+ */
+enum class WidthCategory(val order: Int) {
+    VeryNarrow(0),
+    Narrow(1),
+    Standard(2),
+    Wide(3);
+
+    companion object {
+        /** Determine the width category from a dp value. */
+        fun fromDp(widthDp: Float): WidthCategory = when {
+            widthDp < 300f -> VeryNarrow
+            widthDp < 500f -> Narrow
+            widthDp < 700f -> Standard
+            else -> Wide
+        }
+
+        /** Parse a category name (case-insensitive). Returns null for unrecognized names. */
+        fun fromName(name: String): WidthCategory? = when (name.lowercase()) {
+            "verynarrow" -> VeryNarrow
+            "narrow" -> Narrow
+            "standard" -> Standard
+            "wide" -> Wide
+            else -> null
+        }
+    }
+}
+
+/**
+ * Evaluates whether an element's `targetWidth` constraint matches the current width category.
+ *
+ * Supported formats:
+ * - `"VeryNarrow"`, `"Narrow"`, `"Standard"`, `"Wide"` — exact match
+ * - `"AtLeast:Narrow"` — matches Narrow, Standard, Wide
+ * - `"AtMost:Narrow"` — matches VeryNarrow, Narrow
+ *
+ * Returns `true` if targetWidth is null/blank (element always visible).
+ */
+fun shouldShowForTargetWidth(targetWidth: String?, currentCategory: WidthCategory): Boolean {
+    if (targetWidth.isNullOrBlank()) return true
+
+    val trimmed = targetWidth.trim()
+
+    // "AtLeast:X" — current must be >= X
+    if (trimmed.startsWith("AtLeast:", ignoreCase = true)) {
+        val categoryName = trimmed.substringAfter(":")
+        val threshold = WidthCategory.fromName(categoryName) ?: return true
+        return currentCategory.order >= threshold.order
+    }
+
+    // "AtMost:X" — current must be <= X
+    if (trimmed.startsWith("AtMost:", ignoreCase = true)) {
+        val categoryName = trimmed.substringAfter(":")
+        val threshold = WidthCategory.fromName(categoryName) ?: return true
+        return currentCategory.order <= threshold.order
+    }
+
+    // Exact match
+    val exact = WidthCategory.fromName(trimmed) ?: return true
+    return currentCategory == exact
+}
+
+/**
+ * Extension property to extract targetWidth from any CardElement.
+ * Returns null for element types that don't support it.
+ */
+val CardElement.targetWidth: String?
+    get() = when (this) {
+        is TextBlock -> targetWidth
+        is Image -> targetWidth
+        is Container -> targetWidth
+        is ActionSet -> targetWidth
+        else -> null
+    }

--- a/android/ac-rendering/src/main/kotlin/com/microsoft/adaptivecards/rendering/composables/AdaptiveCardView.kt
+++ b/android/ac-rendering/src/main/kotlin/com/microsoft/adaptivecards/rendering/composables/AdaptiveCardView.kt
@@ -1,13 +1,17 @@
 package com.microsoft.adaptivecards.rendering.composables
 
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.microsoft.adaptivecards.core.hostconfig.HostConfig
 import com.microsoft.adaptivecards.core.models.*
@@ -20,6 +24,15 @@ import com.microsoft.adaptivecards.rendering.viewmodel.ActionHandler
 import com.microsoft.adaptivecards.rendering.viewmodel.CardViewModel
 import com.microsoft.adaptivecards.rendering.viewmodel.DefaultActionHandler
 import com.microsoft.adaptivecards.accessibility.RTLSupport
+import com.microsoft.adaptivecards.core.models.WidthCategory
+import com.microsoft.adaptivecards.core.models.shouldShowForTargetWidth
+import com.microsoft.adaptivecards.core.models.targetWidth
+
+/**
+ * CompositionLocal providing the current card width category for targetWidth filtering.
+ * Defaults to Narrow (typical phone width).
+ */
+val LocalWidthCategory = compositionLocalOf { WidthCategory.Narrow }
 
 /**
  * Main entry point for rendering an Adaptive Card
@@ -72,26 +85,34 @@ fun AdaptiveCardView(
     card?.let { adaptiveCard ->
         HostConfigProvider(hostConfig = hostConfig ?: com.microsoft.adaptivecards.core.hostconfig.HostConfigParser.default()) {
             RTLSupport(isRTL = adaptiveCard.rtl == true) {
-                Column(modifier = modifier.fillMaxWidth()) {
-                    // Render body elements
-                    adaptiveCard.body?.forEachIndexed { index, element ->
-                        RenderElement(
-                            element = element,
-                            isFirst = index == 0,
-                            viewModel = viewModel,
-                            actionHandler = actionHandler
-                        )
-                    }
-                    
-                    // Render actions
-                    adaptiveCard.actions?.let { actions ->
-                        if (actions.isNotEmpty()) {
-                            ActionSetView(
-                                actions = actions,
-                                actionHandler = actionHandler,
-                                viewModel = viewModel,
-                                modifier = Modifier.fillMaxWidth()
-                            )
+                BoxWithConstraints(modifier = modifier.fillMaxWidth()) {
+                    val density = LocalDensity.current
+                    val widthDp = with(density) { constraints.maxWidth.toDp().value }
+                    val widthCategory = WidthCategory.fromDp(widthDp)
+
+                    CompositionLocalProvider(LocalWidthCategory provides widthCategory) {
+                        Column(modifier = Modifier.fillMaxWidth()) {
+                            // Render body elements
+                            adaptiveCard.body?.forEachIndexed { index, element ->
+                                RenderElement(
+                                    element = element,
+                                    isFirst = index == 0,
+                                    viewModel = viewModel,
+                                    actionHandler = actionHandler
+                                )
+                            }
+
+                            // Render actions
+                            adaptiveCard.actions?.let { actions ->
+                                if (actions.isNotEmpty()) {
+                                    ActionSetView(
+                                        actions = actions,
+                                        actionHandler = actionHandler,
+                                        viewModel = viewModel,
+                                        modifier = Modifier.fillMaxWidth()
+                                    )
+                                }
+                            }
                         }
                     }
                 }
@@ -113,9 +134,15 @@ fun RenderElement(
 ) {
     // Check visibility
     if (!element.isVisible) return
-    
+
     val elementId = element.id
     if (elementId != null && !viewModel.isElementVisible(elementId)) {
+        return
+    }
+
+    // Check targetWidth constraint
+    val widthCategory = LocalWidthCategory.current
+    if (!shouldShowForTargetWidth(element.targetWidth, widthCategory)) {
         return
     }
     


### PR DESCRIPTION
## Summary
- **Added `targetWidth` property** to `ActionSet` model (was missing, unlike TextBlock/Image/Container)
- **Created `TargetWidth.kt`** with `WidthCategory` enum (VeryNarrow/Narrow/Standard/Wide breakpoints), `shouldShowForTargetWidth()` evaluator supporting exact match, `AtLeast:`, and `AtMost:` prefixes
- **Added responsive filtering** in `AdaptiveCardView` — wraps card body in `BoxWithConstraints` to measure actual width, provides `LocalWidthCategory` via CompositionLocal, and filters elements in `RenderElement`

## Problem
Both ActionSets in the Teams Recipe card were rendering (one for `AtLeast:Narrow`, one for `VeryNarrow`), causing duplicate buttons with the VeryNarrow variant showing an empty blue button (icon-only action without title).

## Test plan
- [x] Verified Teams Recipe card on Android emulator — only "View recipe" + "Add to cart" buttons render (VeryNarrow ActionSet hidden)
- [ ] Verify other cards with targetWidth constraints render correctly
- [ ] Run `./gradlew test` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)