### PR TITLE
docs: Documentation updates with latest changes 3/11

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Adaptive Cards Mobile SDK Contributors
+Copyright (c) 2024-2026 Adaptive Cards Mobile SDK Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- Update LICENSE copyright year range to 2024-2026

## Test plan
- [ ] No code changes — license only

🤖 Generated with [Claude Code](https://claude.com/claude-code)