### PR TITLE
feat(ios,android): Popover/RunCommands/OpenUrlDialog actions, Input.DataGrid, rendering parity

### DIFF
--- a/android/ac-core/src/main/kotlin/com/microsoft/adaptivecards/core/SchemaValidator.kt
+++ b/android/ac-core/src/main/kotlin/com/microsoft/adaptivecards/core/SchemaValidator.kt
@@ -26,6 +26,8 @@ class SchemaValidator {
             "Container", "ColumnSet", "ImageSet", "FactSet", "ActionSet",
             // Input elements (v1.0)
             "Input.Text", "Input.Number", "Input.Date", "Input.Time", "Input.Toggle", "Input.ChoiceSet",
+            // Input elements (v1.5+)
+            "Input.DataGrid",
             // Advanced elements (v1.3+)
             "Carousel", "Accordion", "CodeBlock", "Rating", "Input.Rating", "ProgressBar", "Spinner",
             "TabSet", "List",

--- a/android/ac-core/src/main/kotlin/com/microsoft/adaptivecards/core/models/AdaptiveCard.kt
+++ b/android/ac-core/src/main/kotlin/com/microsoft/adaptivecards/core/models/AdaptiveCard.kt
@@ -22,5 +22,19 @@ data class AdaptiveCard(
     val rtl: Boolean? = null,
     val refresh: Refresh? = null,
     val authentication: Authentication? = null,
-    val metadata: JsonElement? = null
+    val metadata: JsonElement? = null,
+    val references: List<DocumentReference>? = null
+)
+
+/**
+ * A reference entry for CitationRun inlines.
+ * Parsed from the top-level `references` array in an AdaptiveCard.
+ */
+@Serializable
+data class DocumentReference(
+    val type: String? = null,
+    val title: String? = null,
+    val icon: String? = null,
+    val url: String? = null,
+    val abstract: String? = null
 )

--- a/android/ac-core/src/main/kotlin/com/microsoft/adaptivecards/core/models/CardAction.kt
+++ b/android/ac-core/src/main/kotlin/com/microsoft/adaptivecards/core/models/CardAction.kt
@@ -169,7 +169,7 @@ data class ActionPopover(
     override val requires: Map<String, String>? = null,
     override val fallback: JsonElement? = null,
     val popoverTitle: String? = null,
-    val popoverBody: List<CardElement> = emptyList(),
+    val content: CardElement? = null,
     val dismissBehavior: String? = null
 ) : CardAction
 

--- a/android/ac-core/src/main/kotlin/com/microsoft/adaptivecards/core/models/CardElement.kt
+++ b/android/ac-core/src/main/kotlin/com/microsoft/adaptivecards/core/models/CardElement.kt
@@ -259,14 +259,23 @@ data class RichTextBlock(
     override val height: BlockElementHeight? = null,
     override val requires: Map<String, String>? = null,
     override val fallback: JsonElement? = null,
-    val inlines: List<TextRun>,
+    val inlines: List<InlineElement>,
     val horizontalAlignment: HorizontalAlignment? = null
 ) : CardElement
+
+/**
+ * Polymorphic inline element within a RichTextBlock.
+ * Supports TextRun (styled text) and CitationRun (citation badge).
+ */
+@Serializable(with = com.microsoft.adaptivecards.core.parsing.InlineElementSerializer::class)
+sealed interface InlineElement {
+    val text: String
+}
 
 @Serializable(with = TextRunSerializer::class)
 data class TextRun(
     val type: String = "TextRun",
-    val text: String,
+    override val text: String,
     val color: Color? = null,
     val fontType: FontType? = null,
     val size: FontSize? = null,
@@ -277,7 +286,16 @@ data class TextRun(
     val underline: Boolean? = null,
     val highlight: Boolean? = null,
     val selectAction: CardAction? = null
-)
+) : InlineElement
+
+/**
+ * An inline citation badge that renders as a superscript `[N]` reference.
+ */
+data class CitationRun(
+    val type: String = "CitationRun",
+    override val text: String,
+    val referenceIndex: Int
+) : InlineElement
 
 @Serializable
 @SerialName("Icon")
@@ -365,5 +383,9 @@ data class TableCell(
     val bleed: Boolean? = null,
     val backgroundImage: BackgroundImage? = null,
     val minHeight: String? = null,
-    val rtl: Boolean? = null
-)
+    val rtl: Boolean? = null,
+    val layouts: List<Layout>? = null
+) {
+    /** Active layout — first from layouts array, or null for default stack */
+    val layout: Layout? get() = layouts?.firstOrNull()
+}

--- a/android/ac-core/src/main/kotlin/com/microsoft/adaptivecards/core/models/CompoundButton.kt
+++ b/android/ac-core/src/main/kotlin/com/microsoft/adaptivecards/core/models/CompoundButton.kt
@@ -75,10 +75,11 @@ data class CompoundButton(
     override val requires: Map<String, String>? = null,
     override val fallback: JsonElement? = null,
     val title: String,
-    val subtitle: String? = null,
+    val description: String? = null,
     val icon: IconDescriptor? = null,
     val iconPosition: String? = null,
-    val action: CardAction? = null,
+    val selectAction: CardAction? = null,
+    val badge: String? = null,
     val style: String? = null
 ) : CardElement {
     /** Convenience accessor: the icon name as a string regardless of how it was encoded */

--- a/android/ac-core/src/main/kotlin/com/microsoft/adaptivecards/core/parsing/CardElementSerializer.kt
+++ b/android/ac-core/src/main/kotlin/com/microsoft/adaptivecards/core/parsing/CardElementSerializer.kt
@@ -124,6 +124,9 @@ object CardElementSerializer : KSerializer<CardElement> {
  * Handles both plain string shorthand and full TextRun object in RichTextBlock inlines.
  * Per Adaptive Cards spec, inlines can contain plain strings as shorthand for
  * `{"type": "TextRun", "text": "<string>"}`.
+ *
+ * Also used as the serializer for TextRun when it appears standalone (e.g., in
+ * InlineElementSerializer delegation).
  */
 object TextRunSerializer : KSerializer<TextRun> {
     override val descriptor: SerialDescriptor = buildClassSerialDescriptor("TextRun")
@@ -133,32 +136,33 @@ object TextRunSerializer : KSerializer<TextRun> {
             ?: return TextRun(text = decoder.decodeString())
         return when (val element = jsonDecoder.decodeJsonElement()) {
             is JsonPrimitive -> TextRun(text = element.content)
-            else -> {
-                val obj = element.jsonObject
-                TextRun(
-                    type = obj["type"]?.jsonPrimitive?.content ?: "TextRun",
-                    text = obj["text"]?.jsonPrimitive?.content ?: "",
-                    color = obj["color"]?.jsonPrimitive?.content
-                        ?.let { runCatching { Color.valueOf(it) }.getOrNull() },
-                    fontType = obj["fontType"]?.jsonPrimitive?.content
-                        ?.let { runCatching { FontType.valueOf(it) }.getOrNull() },
-                    size = obj["size"]?.jsonPrimitive?.content
-                        ?.let { runCatching { FontSize.valueOf(it) }.getOrNull() },
-                    weight = obj["weight"]?.jsonPrimitive?.content
-                        ?.let { runCatching { FontWeight.valueOf(it) }.getOrNull() },
-                    isSubtle = obj["isSubtle"]?.jsonPrimitive?.content?.toBooleanStrictOrNull(),
-                    italic = obj["italic"]?.jsonPrimitive?.content?.toBooleanStrictOrNull(),
-                    strikethrough = obj["strikethrough"]?.jsonPrimitive?.content?.toBooleanStrictOrNull(),
-                    underline = obj["underline"]?.jsonPrimitive?.content?.toBooleanStrictOrNull(),
-                    highlight = obj["highlight"]?.jsonPrimitive?.content?.toBooleanStrictOrNull(),
-                    selectAction = obj["selectAction"]?.let {
-                        runCatching {
-                            jsonDecoder.json.decodeFromJsonElement(CardAction.serializer(), it)
-                        }.getOrNull()
-                    }
-                )
-            }
+            else -> decodeTextRunFromJsonObject(element.jsonObject, jsonDecoder)
         }
+    }
+
+    internal fun decodeTextRunFromJsonObject(obj: JsonObject, jsonDecoder: JsonDecoder): TextRun {
+        return TextRun(
+            type = obj["type"]?.jsonPrimitive?.content ?: "TextRun",
+            text = obj["text"]?.jsonPrimitive?.content ?: "",
+            color = obj["color"]?.jsonPrimitive?.content
+                ?.let { runCatching { Color.valueOf(it) }.getOrNull() },
+            fontType = obj["fontType"]?.jsonPrimitive?.content
+                ?.let { runCatching { FontType.valueOf(it) }.getOrNull() },
+            size = obj["size"]?.jsonPrimitive?.content
+                ?.let { runCatching { FontSize.valueOf(it) }.getOrNull() },
+            weight = obj["weight"]?.jsonPrimitive?.content
+                ?.let { runCatching { FontWeight.valueOf(it) }.getOrNull() },
+            isSubtle = obj["isSubtle"]?.jsonPrimitive?.content?.toBooleanStrictOrNull(),
+            italic = obj["italic"]?.jsonPrimitive?.content?.toBooleanStrictOrNull(),
+            strikethrough = obj["strikethrough"]?.jsonPrimitive?.content?.toBooleanStrictOrNull(),
+            underline = obj["underline"]?.jsonPrimitive?.content?.toBooleanStrictOrNull(),
+            highlight = obj["highlight"]?.jsonPrimitive?.content?.toBooleanStrictOrNull(),
+            selectAction = obj["selectAction"]?.let {
+                runCatching {
+                    jsonDecoder.json.decodeFromJsonElement(CardAction.serializer(), it)
+                }.getOrNull()
+            }
+        )
     }
 
     override fun serialize(encoder: Encoder, value: TextRun) {
@@ -180,6 +184,49 @@ object TextRunSerializer : KSerializer<TextRun> {
             }
         }
         jsonEncoder.encodeJsonElement(JsonObject(obj))
+    }
+}
+
+/**
+ * Polymorphic serializer for InlineElement within RichTextBlock inlines.
+ * Routes to TextRun or CitationRun based on the "type" field.
+ * Handles plain string shorthand (maps to TextRun).
+ */
+object InlineElementSerializer : KSerializer<InlineElement> {
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("InlineElement")
+
+    override fun deserialize(decoder: Decoder): InlineElement {
+        val jsonDecoder = decoder as? JsonDecoder
+            ?: return TextRun(text = decoder.decodeString())
+        return when (val element = jsonDecoder.decodeJsonElement()) {
+            is JsonPrimitive -> TextRun(text = element.content)
+            else -> {
+                val obj = element.jsonObject
+                val type = obj["type"]?.jsonPrimitive?.content
+                when (type) {
+                    "CitationRun" -> CitationRun(
+                        text = obj["text"]?.jsonPrimitive?.content ?: "",
+                        referenceIndex = obj["referenceIndex"]?.jsonPrimitive?.content?.toIntOrNull() ?: 0
+                    )
+                    else -> TextRunSerializer.decodeTextRunFromJsonObject(obj, jsonDecoder)
+                }
+            }
+        }
+    }
+
+    override fun serialize(encoder: Encoder, value: InlineElement) {
+        val jsonEncoder = encoder as? JsonEncoder ?: return
+        when (value) {
+            is TextRun -> TextRunSerializer.serialize(encoder, value)
+            is CitationRun -> {
+                val obj = buildMap<String, kotlinx.serialization.json.JsonElement> {
+                    put("type", JsonPrimitive(value.type))
+                    put("text", JsonPrimitive(value.text))
+                    put("referenceIndex", JsonPrimitive(value.referenceIndex))
+                }
+                jsonEncoder.encodeJsonElement(JsonObject(obj))
+            }
+        }
     }
 }
 

--- a/android/ac-core/src/test/kotlin/AdvancedElementsParserTest.kt
+++ b/android/ac-core/src/test/kotlin/AdvancedElementsParserTest.kt
@@ -527,11 +527,11 @@ class AdvancedElementsParserTest {
                         "type": "CompoundButton",
                         "id": "btn1",
                         "title": "Approve Request",
-                        "subtitle": "Review and approve the pending request",
+                        "description": "Review and approve the pending request",
                         "icon": "checkmark.circle.fill",
                         "iconPosition": "leading",
                         "style": "positive",
-                        "action": {
+                        "selectAction": {
                             "type": "Action.Submit",
                             "title": "Approve",
                             "data": {
@@ -550,11 +550,11 @@ class AdvancedElementsParserTest {
         
         assertEquals("btn1", button.id)
         assertEquals("Approve Request", button.title)
-        assertEquals("Review and approve the pending request", button.subtitle)
+        assertEquals("Review and approve the pending request", button.description)
         assertEquals("checkmark.circle.fill", button.iconName)
         assertEquals("leading", button.iconPosition)
         assertEquals("positive", button.style)
-        assertNotNull(button.action)
+        assertNotNull(button.selectAction)
     }
     
     @Test
@@ -568,10 +568,10 @@ class AdvancedElementsParserTest {
                         "type": "CompoundButton",
                         "id": "btn_emphasis",
                         "title": "Primary Action",
-                        "subtitle": "With accent color",
+                        "description": "With accent color",
                         "icon": "star.fill",
                         "style": "emphasis",
-                        "action": {
+                        "selectAction": {
                             "type": "Action.Submit",
                             "title": "Submit"
                         }
@@ -598,10 +598,10 @@ class AdvancedElementsParserTest {
                         "type": "CompoundButton",
                         "id": "btn_delete",
                         "title": "Delete Item",
-                        "subtitle": "This action cannot be undone",
+                        "description": "This action cannot be undone",
                         "icon": "trash",
                         "style": "destructive",
-                        "action": {
+                        "selectAction": {
                             "type": "Action.Submit",
                             "title": "Delete",
                             "data": {
@@ -631,10 +631,10 @@ class AdvancedElementsParserTest {
                         "type": "CompoundButton",
                         "id": "btn_trailing",
                         "title": "Navigate",
-                        "subtitle": "Open external link",
+                        "description": "Open external link",
                         "icon": "arrow.right.circle",
                         "iconPosition": "trailing",
-                        "action": {
+                        "selectAction": {
                             "type": "Action.OpenUrl",
                             "url": "https://example.com"
                         }
@@ -661,8 +661,8 @@ class AdvancedElementsParserTest {
                         "type": "CompoundButton",
                         "id": "btn_no_icon",
                         "title": "Submit Form",
-                        "subtitle": "Send your response",
-                        "action": {
+                        "description": "Send your response",
+                        "selectAction": {
                             "type": "Action.Submit"
                         }
                     }
@@ -674,7 +674,7 @@ class AdvancedElementsParserTest {
         val button = card.body?.first() as CompoundButton
         
         assertNull(button.icon)
-        assertNotNull(button.subtitle)
+        assertNotNull(button.description)
     }
     
     @Test
@@ -689,7 +689,7 @@ class AdvancedElementsParserTest {
                         "id": "btn_no_subtitle",
                         "title": "Quick Action",
                         "icon": "bolt.fill",
-                        "action": {
+                        "selectAction": {
                             "type": "Action.Submit"
                         }
                     }
@@ -700,7 +700,7 @@ class AdvancedElementsParserTest {
         val card = CardParser.parse(json)
         val button = card.body?.first() as CompoundButton
         
-        assertNull(button.subtitle)
+        assertNull(button.description)
         assertNotNull(button.icon)
     }
     
@@ -715,7 +715,7 @@ class AdvancedElementsParserTest {
                         "type": "CompoundButton",
                         "id": "btn_disabled",
                         "title": "Disabled Button",
-                        "subtitle": "No action associated"
+                        "description": "No action associated"
                     }
                 ]
             }
@@ -724,7 +724,7 @@ class AdvancedElementsParserTest {
         val card = CardParser.parse(json)
         val button = card.body?.first() as CompoundButton
         
-        assertNull(button.action)
+        assertNull(button.selectAction)
     }
     
     @Test
@@ -735,11 +735,11 @@ class AdvancedElementsParserTest {
                 CompoundButton(
                     id = "btn1",
                     title = "Test Button",
-                    subtitle = "Test subtitle",
+                    description = "Test subtitle",
                     icon = IconDescriptor(name = "star.fill"),
                     iconPosition = "leading",
                     style = "emphasis",
-                    action = ActionSubmit(
+                    selectAction = ActionSubmit(
                         title = "Submit",
                         data = kotlinx.serialization.json.JsonObject(mapOf("action" to kotlinx.serialization.json.JsonPrimitive("test")))
                     )
@@ -754,10 +754,10 @@ class AdvancedElementsParserTest {
         val button = parsedCard.body?.first() as CompoundButton
         assertEquals("btn1", button.id)
         assertEquals("Test Button", button.title)
-        assertEquals("Test subtitle", button.subtitle)
+        assertEquals("Test subtitle", button.description)
         assertEquals("star.fill", button.iconName)
         assertEquals("leading", button.iconPosition)
         assertEquals("emphasis", button.style)
-        assertNotNull(button.action)
+        assertNotNull(button.selectAction)
     }
 }

--- a/android/ac-rendering/build.gradle.kts
+++ b/android/ac-rendering/build.gradle.kts
@@ -66,6 +66,7 @@ dependencies {
     
     // Image Loading
     implementation(libs.coil.compose)
+    implementation(libs.coil.svg)
 
     debugImplementation(libs.compose.ui.tooling)
 

--- a/android/ac-rendering/src/main/kotlin/com/microsoft/adaptivecards/rendering/composables/ActionSetView.kt
+++ b/android/ac-rendering/src/main/kotlin/com/microsoft/adaptivecards/rendering/composables/ActionSetView.kt
@@ -1,6 +1,7 @@
 package com.microsoft.adaptivecards.rendering.composables
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -10,9 +11,12 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -23,7 +27,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.microsoft.adaptivecards.core.models.*
 import com.microsoft.adaptivecards.rendering.theme.LocalHostConfig
@@ -63,28 +69,89 @@ fun ActionSetView(
 
     val isLeftAligned = hostConfig.actions.actionAlignment == "left"
 
-    Row(
-        modifier = modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(
-            hostConfig.actions.buttonSpacing.dp
-        )
-    ) {
-        visibleActions.forEach { action ->
-            ActionButton(
-                action = action,
-                actionHandler = actionHandler,
-                viewModel = viewModel,
-                modifier = if (isLeftAligned) Modifier else Modifier.weight(1f)
+    Column(modifier = modifier) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(
+                hostConfig.actions.buttonSpacing.dp
             )
+        ) {
+            visibleActions.forEach { action ->
+                ActionButton(
+                    action = action,
+                    actionHandler = actionHandler,
+                    viewModel = viewModel,
+                    modifier = if (isLeftAligned) Modifier else Modifier.weight(1f)
+                )
+            }
+
+            // Overflow menu for secondary actions
+            if (secondaryActions.isNotEmpty()) {
+                OverflowMenuButton(
+                    actions = secondaryActions,
+                    actionHandler = actionHandler,
+                    viewModel = viewModel
+                )
+            }
         }
 
-        // Overflow menu for secondary actions
-        if (secondaryActions.isNotEmpty()) {
-            OverflowMenuButton(
-                actions = secondaryActions,
-                actionHandler = actionHandler,
-                viewModel = viewModel
-            )
+        // Render expanded ShowCard sub-cards inline
+        val showCardActions = actions.filterIsInstance<ActionShowCard>()
+        showCardActions.forEach { showCardAction ->
+            val actionId = showCardAction.id ?: "showCard_${showCardAction.title ?: "unknown"}"
+            if (viewModel.isShowCardExpanded(actionId)) {
+                val emphasisBg = Color(
+                    android.graphics.Color.parseColor(
+                        hostConfig.containerStyles.emphasis.backgroundColor
+                    )
+                )
+                val cornerRadius = hostConfig.cornerRadius.container.dp
+
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = hostConfig.spacing.default.dp)
+                        .background(
+                            color = emphasisBg,
+                            shape = RoundedCornerShape(cornerRadius)
+                        )
+                        .padding(hostConfig.spacing.padding.dp)
+                ) {
+                    showCardAction.card.body?.forEachIndexed { index, element ->
+                        RenderElement(
+                            element = element,
+                            isFirst = index == 0,
+                            viewModel = viewModel,
+                            actionHandler = actionHandler
+                        )
+                    }
+                    // Render sub-card actions if present
+                    showCardAction.card.actions?.let { subActions ->
+                        if (subActions.isNotEmpty()) {
+                            Spacer(modifier = Modifier.height(hostConfig.spacing.default.dp))
+                            ActionSetView(
+                                actions = subActions,
+                                actionHandler = actionHandler,
+                                viewModel = viewModel
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        // Render popover bottom sheets for any ActionPopover actions that are showing
+        val popoverActions = actions.filterIsInstance<ActionPopover>()
+        popoverActions.forEach { popoverAction ->
+            val actionId = popoverAction.id ?: return@forEach
+            if (viewModel.isPopoverShowing(actionId)) {
+                PopoverBottomSheet(
+                    action = popoverAction,
+                    viewModel = viewModel,
+                    actionHandler = actionHandler,
+                    onDismiss = { viewModel.dismissPopover(actionId) }
+                )
+            }
         }
     }
 }
@@ -299,6 +366,57 @@ private fun resolveFluentIcon(name: String): ImageVector? {
 }
 
 /**
+ * Renders an ActionPopover's content inside a Material3 ModalBottomSheet.
+ *
+ * The bottom sheet does not steal focus and supports nested popovers
+ * (each popover tracks its own state via viewModel.popoverState).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun PopoverBottomSheet(
+    action: ActionPopover,
+    viewModel: CardViewModel,
+    actionHandler: ActionHandler,
+    onDismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val hostConfig = LocalHostConfig.current
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = hostConfig.spacing.padding.dp)
+                .padding(bottom = hostConfig.spacing.padding.dp)
+        ) {
+            // Popover title
+            val title = action.popoverTitle ?: action.title
+            if (!title.isNullOrBlank()) {
+                Text(
+                    text = title,
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.padding(bottom = hostConfig.spacing.default.dp)
+                )
+            }
+
+            // Render the popover content element using the standard rendering pipeline
+            action.content?.let { contentElement ->
+                RenderElement(
+                    element = contentElement,
+                    isFirst = true,
+                    viewModel = viewModel,
+                    actionHandler = actionHandler
+                )
+            }
+        }
+    }
+}
+
+/**
  * Handle action execution
  */
 private fun handleAction(
@@ -319,6 +437,8 @@ private fun handleAction(
             actionHandler.onExecute(action.verb ?: "", inputData, action.id)
         }
         is ActionShowCard -> {
+            val actionId = action.id ?: "showCard_${action.title ?: "unknown"}"
+            viewModel.toggleShowCard(actionId)
             actionHandler.onShowCard(action)
         }
         is ActionToggleVisibility -> {
@@ -331,7 +451,8 @@ private fun handleAction(
             actionHandler.onOpenUrl(action.url, action.id)
         }
         is ActionPopover -> {
-            // Popover actions handled externally
+            val actionId = action.id ?: return
+            viewModel.togglePopover(actionId)
         }
         is ActionRunCommands -> {
             // RunCommands actions handled externally

--- a/android/ac-rendering/src/main/kotlin/com/microsoft/adaptivecards/rendering/composables/CompoundButtonView.kt
+++ b/android/ac-rendering/src/main/kotlin/com/microsoft/adaptivecards/rendering/composables/CompoundButtonView.kt
@@ -1,6 +1,8 @@
 package com.microsoft.adaptivecards.rendering.composables
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -30,10 +32,11 @@ private object CompoundButtonLayout {
     val CornerRadius = 8.dp
     val MinHeight = 48.dp
     val Elevation = 2.dp
+    val BadgeFontSize = 10.sp
 }
 
 /**
- * Renders a CompoundButton element with icon, title, and subtitle
+ * Renders a CompoundButton element with icon, title, description, and badge
  */
 @OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
 @Composable
@@ -44,26 +47,26 @@ fun CompoundButtonView(
 ) {
     val containerColor = when (element.style) {
         "emphasis" -> MaterialTheme.colorScheme.primary
-        "positive" -> Color(0xFF4CAF50) // Green
-        "destructive" -> Color(0xFFF44336) // Red
+        "positive" -> Color(0xFF4CAF50)
+        "destructive" -> Color(0xFFF44336)
         else -> MaterialTheme.colorScheme.surface
     }
-    
+
     val contentColor = when (element.style) {
         "emphasis", "positive", "destructive" -> Color.White
         else -> MaterialTheme.colorScheme.onSurface
     }
-    
-    val isEnabled = element.action != null
-    
+
+    val isEnabled = element.selectAction != null
+
     val contentDesc = buildString {
         append(element.title)
-        element.subtitle?.let { append(". $it") }
+        element.description?.let { append(". $it") }
     }
-    
+
     Card(
         onClick = {
-            element.action?.let { action ->
+            element.selectAction?.let { action ->
                 when (action) {
                     is com.microsoft.adaptivecards.core.models.ActionOpenUrl -> actionHandler.onOpenUrl(action.url, action.id)
                     is com.microsoft.adaptivecards.core.models.ActionSubmit -> actionHandler.onSubmit(emptyMap(), action.id)
@@ -100,24 +103,46 @@ fun CompoundButtonView(
             if (element.iconPosition != "trailing") {
                 IconView(element.iconName, contentColor)
             }
-            
-            // Title and subtitle
+
+            // Title, badge, and description
             Column(
                 modifier = Modifier.weight(1f),
                 verticalArrangement = Arrangement.spacedBy(CompoundButtonLayout.TitleSubtitleSpacing)
             ) {
-                Text(
-                    text = element.title,
-                    fontSize = 16.sp,
-                    fontWeight = FontWeight.SemiBold,
-                    color = contentColor,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis
-                )
-                
-                element.subtitle?.let { subtitle ->
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
                     Text(
-                        text = subtitle,
+                        text = element.title,
+                        fontSize = 16.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        color = contentColor,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f, fill = false)
+                    )
+
+                    element.badge?.let { badge ->
+                        Text(
+                            text = badge,
+                            fontSize = CompoundButtonLayout.BadgeFontSize,
+                            fontWeight = FontWeight.SemiBold,
+                            color = Color.White,
+                            maxLines = 1,
+                            modifier = Modifier
+                                .background(
+                                    MaterialTheme.colorScheme.primary,
+                                    RoundedCornerShape(4.dp)
+                                )
+                                .padding(horizontal = 6.dp, vertical = 2.dp)
+                        )
+                    }
+                }
+
+                element.description?.let { description ->
+                    Text(
+                        text = description,
                         fontSize = 14.sp,
                         color = contentColor.copy(alpha = 0.7f),
                         maxLines = 2,
@@ -125,12 +150,12 @@ fun CompoundButtonView(
                     )
                 }
             }
-            
+
             // Trailing icon
             if (element.iconPosition == "trailing") {
                 IconView(element.iconName, contentColor)
             }
-            
+
             // Chevron indicator
             Icon(
                 painter = painterResource(android.R.drawable.ic_menu_more),
@@ -145,9 +170,8 @@ fun CompoundButtonView(
 @Composable
 private fun IconView(iconString: String?, tintColor: Color) {
     if (iconString == null) return
-    
+
     if (iconString.startsWith("http://") || iconString.startsWith("https://")) {
-        // Load from URL
         AsyncImage(
             model = ImageRequest.Builder(LocalContext.current)
                 .data(iconString)
@@ -160,8 +184,6 @@ private fun IconView(iconString: String?, tintColor: Color) {
             placeholder = painterResource(android.R.drawable.ic_menu_gallery)
         )
     } else {
-        // Material Icon - for now show a placeholder
-        // In a real app, you'd map icon names to Material Icons
         Icon(
             painter = painterResource(android.R.drawable.ic_menu_info_details),
             contentDescription = null,

--- a/android/ac-rendering/src/main/kotlin/com/microsoft/adaptivecards/rendering/composables/ImageView.kt
+++ b/android/ac-rendering/src/main/kotlin/com/microsoft/adaptivecards/rendering/composables/ImageView.kt
@@ -11,8 +11,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import coil.decode.SvgDecoder
+import coil.request.ImageRequest
 import com.microsoft.adaptivecards.core.models.Image
 import com.microsoft.adaptivecards.core.models.ImageSize
 import com.microsoft.adaptivecards.core.models.ImageStyle
@@ -26,6 +29,7 @@ import com.microsoft.adaptivecards.accessibility.imageSemantics
  *
  * Sizes resolved from HostConfig.imageSizes (Figma: small=32, medium=52, large=100).
  * Corner radius applied from HostConfig.cornerRadius.image (4dp) except for Person style.
+ * SVG images supported via Coil's SvgDecoder (both URL and data:image/svg+xml URIs).
  */
 @Composable
 fun ImageView(
@@ -35,6 +39,10 @@ fun ImageView(
 ) {
     val hostConfig = LocalHostConfig.current
     val cornerRadius = hostConfig.cornerRadius.image
+    val context = LocalContext.current
+
+    // Skip symbol: URLs (platform-specific, not renderable)
+    if (element.url.startsWith("symbol:")) return
 
     // Determine image size
     val imageModifier = when (element.size ?: ImageSize.Auto) {
@@ -51,7 +59,6 @@ fun ImageView(
                 widthPx != null -> modifier.width(widthPx.dp)
                 heightPx != null -> modifier.height(heightPx.dp)
                 // Auto per AC spec: display at natural size constrained to container width.
-                // Images with explicit pixel dimensions (avatars etc.) are handled above.
                 else -> modifier.fillMaxWidth()
             }
         }
@@ -64,8 +71,22 @@ fun ImageView(
         else -> if (cornerRadius > 0) imageModifier.clip(RoundedCornerShape(cornerRadius.dp)) else imageModifier
     }
 
+    // Build image request — add SVG decoder for SVG content
+    val isSvg = element.url.endsWith(".svg", ignoreCase = true) ||
+        element.url.startsWith("data:image/svg+xml")
+
+    val model = ImageRequest.Builder(context)
+        .data(element.url)
+        .apply {
+            if (isSvg) {
+                decoderFactory(SvgDecoder.Factory())
+            }
+        }
+        .crossfade(true)
+        .build()
+
     AsyncImage(
-        model = element.url,
+        model = model,
         contentDescription = element.altText,
         contentScale = when {
             element.size == ImageSize.Stretch -> ContentScale.Crop

--- a/android/ac-rendering/src/main/kotlin/com/microsoft/adaptivecards/rendering/composables/LayoutViews.kt
+++ b/android/ac-rendering/src/main/kotlin/com/microsoft/adaptivecards/rendering/composables/LayoutViews.kt
@@ -157,6 +157,24 @@ fun AreaGridLayoutView(
 ) {
     val colSpacing = spacingToDp(gridLayout.columnSpacing ?: Spacing.Default, hostConfig)
     val rowSpacing = spacingToDp(gridLayout.rowSpacing ?: Spacing.Default, hostConfig)
+
+    // When no areas are defined, fall back to vertical stack (graceful degradation)
+    if (gridLayout.areas.isEmpty()) {
+        Column(
+            modifier = modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(rowSpacing)
+        ) {
+            items.forEach { item ->
+                RenderElement(
+                    element = item,
+                    viewModel = viewModel,
+                    actionHandler = actionHandler
+                )
+            }
+        }
+        return
+    }
+
     val maxRow = gridLayout.areas.maxOfOrNull { it.row + (it.rowSpan ?: 1) - 1 } ?: 1
     val columnCount = gridLayout.columns.size.coerceAtLeast(1)
 

--- a/android/ac-rendering/src/main/kotlin/com/microsoft/adaptivecards/rendering/composables/MediaAndTableViews.kt
+++ b/android/ac-rendering/src/main/kotlin/com/microsoft/adaptivecards/rendering/composables/MediaAndTableViews.kt
@@ -166,21 +166,43 @@ fun TableView(
                             else -> Alignment.Start
                         }
                     ) {
-                        cell.items?.forEachIndexed { index, item ->
-                            // Apply bold for header cells
-                            if (isHeader && item is TextBlock) {
-                                Text(
-                                    text = item.text,
-                                    fontWeight = FontWeight.Bold,
-                                    style = MaterialTheme.typography.bodyMedium
-                                )
-                            } else {
-                                RenderElement(
-                                    element = item,
-                                    isFirst = index == 0,
+                        val cellLayout = cell.layout
+                        val cellItems = cell.items
+                        if (cellLayout != null && cellItems != null) {
+                            // Render with the cell's layout
+                            when (cellLayout) {
+                                is FlowLayout -> FlowLayoutView(
+                                    items = cellItems,
+                                    flowLayout = cellLayout,
+                                    hostConfig = hostConfig,
                                     viewModel = viewModel,
                                     actionHandler = actionHandler
                                 )
+                                is AreaGridLayout -> AreaGridLayoutView(
+                                    items = cellItems,
+                                    gridLayout = cellLayout,
+                                    hostConfig = hostConfig,
+                                    viewModel = viewModel,
+                                    actionHandler = actionHandler
+                                )
+                            }
+                        } else {
+                            cell.items?.forEachIndexed { index, item ->
+                                // Apply bold for header cells
+                                if (isHeader && item is TextBlock) {
+                                    Text(
+                                        text = item.text,
+                                        fontWeight = FontWeight.Bold,
+                                        style = MaterialTheme.typography.bodyMedium
+                                    )
+                                } else {
+                                    RenderElement(
+                                        element = item,
+                                        isFirst = index == 0,
+                                        viewModel = viewModel,
+                                        actionHandler = actionHandler
+                                    )
+                                }
                             }
                         }
                     }

--- a/android/ac-rendering/src/main/kotlin/com/microsoft/adaptivecards/rendering/composables/RichTextBlockView.kt
+++ b/android/ac-rendering/src/main/kotlin/com/microsoft/adaptivecards/rendering/composables/RichTextBlockView.kt
@@ -10,11 +10,14 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.BaselineShift
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.sp
+import com.microsoft.adaptivecards.core.models.CitationRun
 import com.microsoft.adaptivecards.core.models.HorizontalAlignment
 import com.microsoft.adaptivecards.core.models.RichTextBlock
+import com.microsoft.adaptivecards.core.models.TextRun
 import com.microsoft.adaptivecards.rendering.theme.LocalHostConfig
 import com.microsoft.adaptivecards.rendering.viewmodel.ActionHandler
 import com.microsoft.adaptivecards.accessibility.scaledTextSize
@@ -22,7 +25,8 @@ import com.microsoft.adaptivecards.accessibility.scaledTextSize
 /**
  * Renders a RichTextBlock with styled inline text runs.
  * Supports: bold, italic, strikethrough, underline, highlight, color,
- * font size/weight from HostConfig, and clickable links via selectAction.
+ * font size/weight from HostConfig, clickable links via selectAction,
+ * and CitationRun inline citation badges.
  */
 @Composable
 fun RichTextBlockView(
@@ -34,76 +38,107 @@ fun RichTextBlockView(
     val uriHandler = LocalUriHandler.current
 
     val annotatedText = buildAnnotatedString {
-        element.inlines.forEach { textRun ->
-            val start = length
-            append(textRun.text)
-            val end = length
+        element.inlines.forEach { inline ->
+            when (inline) {
+                is TextRun -> {
+                    val textRun = inline
+                    val start = length
+                    append(textRun.text)
+                    val end = length
 
-            // Resolve font size from HostConfig
-            val fontSize = resolveFontSize(
-                textRun.size ?: com.microsoft.adaptivecards.core.models.FontSize.Default,
-                hostConfig
-            )
+                    // Resolve font size from HostConfig
+                    val fontSize = resolveFontSize(
+                        textRun.size ?: com.microsoft.adaptivecards.core.models.FontSize.Default,
+                        hostConfig
+                    )
 
-            // Resolve font weight from HostConfig
-            val fontWeight = resolveFontWeight(
-                textRun.weight ?: com.microsoft.adaptivecards.core.models.FontWeight.Default,
-                hostConfig
-            )
+                    // Resolve font weight from HostConfig
+                    val fontWeight = resolveFontWeight(
+                        textRun.weight ?: com.microsoft.adaptivecards.core.models.FontWeight.Default,
+                        hostConfig
+                    )
 
-            // Resolve color from HostConfig
-            val textColor = getTextColor(
-                textRun.color ?: com.microsoft.adaptivecards.core.models.Color.Default,
-                textRun.isSubtle ?: false,
-                hostConfig
-            )
-
-            // Build text decoration (supports combining strikethrough + underline)
-            val decorations = mutableListOf<TextDecoration>()
-            if (textRun.strikethrough == true) decorations.add(TextDecoration.LineThrough)
-            if (textRun.underline == true) decorations.add(TextDecoration.Underline)
-
-            // Link styling: underline + accent color
-            val isLink = textRun.selectAction != null
-            if (isLink) decorations.add(TextDecoration.Underline)
-
-            val finalColor = if (isLink) {
-                getTextColor(
-                    com.microsoft.adaptivecards.core.models.Color.Accent,
-                    false,
-                    hostConfig
-                )
-            } else {
-                textColor
-            }
-
-            val spanStyle = SpanStyle(
-                fontSize = scaledTextSize(fontSize),
-                fontWeight = fontWeight,
-                fontStyle = if (textRun.italic == true) FontStyle.Italic else FontStyle.Normal,
-                color = finalColor,
-                textDecoration = if (decorations.isNotEmpty()) {
-                    TextDecoration.combine(decorations)
-                } else {
-                    TextDecoration.None
-                },
-                background = if (textRun.highlight == true) {
-                    getHighlightColor(
+                    // Resolve color from HostConfig
+                    val textColor = getTextColor(
                         textRun.color ?: com.microsoft.adaptivecards.core.models.Color.Default,
                         textRun.isSubtle ?: false,
                         hostConfig
                     )
-                } else {
-                    Color.Transparent
-                }
-            )
-            addStyle(spanStyle, start, end)
 
-            // Add URL annotation for clickable links
-            if (isLink) {
-                val action = textRun.selectAction
-                if (action is com.microsoft.adaptivecards.core.models.ActionOpenUrl) {
-                    addStringAnnotation("URL", action.url, start, end)
+                    // Build text decoration (supports combining strikethrough + underline)
+                    val decorations = mutableListOf<TextDecoration>()
+                    if (textRun.strikethrough == true) decorations.add(TextDecoration.LineThrough)
+                    if (textRun.underline == true) decorations.add(TextDecoration.Underline)
+
+                    // Link styling: underline + accent color
+                    val isLink = textRun.selectAction != null
+                    if (isLink) decorations.add(TextDecoration.Underline)
+
+                    val finalColor = if (isLink) {
+                        getTextColor(
+                            com.microsoft.adaptivecards.core.models.Color.Accent,
+                            false,
+                            hostConfig
+                        )
+                    } else {
+                        textColor
+                    }
+
+                    val spanStyle = SpanStyle(
+                        fontSize = scaledTextSize(fontSize),
+                        fontWeight = fontWeight,
+                        fontStyle = if (textRun.italic == true) FontStyle.Italic else FontStyle.Normal,
+                        color = finalColor,
+                        textDecoration = if (decorations.isNotEmpty()) {
+                            TextDecoration.combine(decorations)
+                        } else {
+                            TextDecoration.None
+                        },
+                        background = if (textRun.highlight == true) {
+                            getHighlightColor(
+                                textRun.color ?: com.microsoft.adaptivecards.core.models.Color.Default,
+                                textRun.isSubtle ?: false,
+                                hostConfig
+                            )
+                        } else {
+                            Color.Transparent
+                        }
+                    )
+                    addStyle(spanStyle, start, end)
+
+                    // Add URL annotation for clickable links
+                    if (isLink) {
+                        val action = textRun.selectAction
+                        if (action is com.microsoft.adaptivecards.core.models.ActionOpenUrl) {
+                            addStringAnnotation("URL", action.url, start, end)
+                        }
+                    }
+                }
+
+                is CitationRun -> {
+                    val badgeText = "[${inline.referenceIndex}]"
+                    val start = length
+                    append(badgeText)
+                    val end = length
+
+                    val accentColor = getTextColor(
+                        com.microsoft.adaptivecards.core.models.Color.Accent,
+                        false,
+                        hostConfig
+                    )
+
+                    val smallFontSize = resolveFontSize(
+                        com.microsoft.adaptivecards.core.models.FontSize.Small,
+                        hostConfig
+                    )
+
+                    val spanStyle = SpanStyle(
+                        fontSize = scaledTextSize(smallFontSize),
+                        fontWeight = FontWeight.SemiBold,
+                        color = accentColor,
+                        baselineShift = BaselineShift.Superscript
+                    )
+                    addStyle(spanStyle, start, end)
                 }
             }
         }

--- a/android/ac-rendering/src/main/kotlin/com/microsoft/adaptivecards/rendering/viewmodel/CardViewModel.kt
+++ b/android/ac-rendering/src/main/kotlin/com/microsoft/adaptivecards/rendering/viewmodel/CardViewModel.kt
@@ -112,6 +112,7 @@ class CardViewModel : ViewModel() {
     val inputValues: SnapshotStateMap<String, Any> = mutableStateMapOf()
     val visibilityState: SnapshotStateMap<String, Boolean> = mutableStateMapOf()
     val showCardState: SnapshotStateMap<String, Boolean> = mutableStateMapOf()
+    val popoverState: SnapshotStateMap<String, Boolean> = mutableStateMapOf()
     val validationErrors: SnapshotStateMap<String, String> = mutableStateMapOf()
     
     // StateFlow API - Read-only reactive views for backward compatibility
@@ -143,13 +144,14 @@ class CardViewModel : ViewModel() {
     fun parseCard(jsonString: String, templateData: Map<String, Any?>? = null) {
         viewModelScope.launch {
             try {
-                var cardJson = jsonString
+                // Resolve ${rs:key} string resources before any other processing
+                var cardJson = templateEngine.resolveStringResources(jsonString)
 
                 // If template data provided, expand template first
                 if (templateData != null) {
                     storedTemplate = jsonString
                     storedTemplateData = templateData
-                    cardJson = templateEngine.expand(jsonString, templateData)
+                    cardJson = templateEngine.expand(cardJson, templateData)
                 } else {
                     storedTemplate = null
                     storedTemplateData = null
@@ -255,7 +257,7 @@ class CardViewModel : ViewModel() {
                     element.actions.forEach { action ->
                         when (action) {
                             is ActionShowCard -> action.card.body?.forEach { validateElement(it) }
-                            is ActionPopover -> action.popoverBody.forEach { validateElement(it) }
+                            is ActionPopover -> action.content?.let { validateElement(it) }
                             else -> {}
                         }
                     }
@@ -331,7 +333,29 @@ class CardViewModel : ViewModel() {
     fun isShowCardExpanded(actionId: String): Boolean {
         return showCardState[actionId] ?: false
     }
-    
+
+    /**
+     * Toggle popover state - O(1) operation with SnapshotStateMap
+     */
+    fun togglePopover(actionId: String) {
+        val currentState = popoverState[actionId] ?: false
+        popoverState[actionId] = !currentState
+    }
+
+    /**
+     * Check if a popover is currently showing
+     */
+    fun isPopoverShowing(actionId: String): Boolean {
+        return popoverState[actionId] ?: false
+    }
+
+    /**
+     * Dismiss a popover
+     */
+    fun dismissPopover(actionId: String) {
+        popoverState[actionId] = false
+    }
+
     /**
      * Set validation error for an input - O(1) operation with SnapshotStateMap
      */
@@ -377,11 +401,13 @@ class CardViewModel : ViewModel() {
         val savedInputs = inputValues.toMap()
         val savedVisibility = visibilityState.toMap()
         val savedShowCards = showCardState.toMap()
+        val savedPopovers = popoverState.toMap()
         parseCard(template, newData)
         // Restore user state after re-parse
         inputValues.putAll(savedInputs)
         visibilityState.putAll(savedVisibility)
         showCardState.putAll(savedShowCards)
+        popoverState.putAll(savedPopovers)
     }
 
     /**
@@ -392,6 +418,7 @@ class CardViewModel : ViewModel() {
         inputValues.clear()
         visibilityState.clear()
         showCardState.clear()
+        popoverState.clear()
         validationErrors.clear()
     }
 

--- a/android/ac-templating/src/main/kotlin/com/microsoft/adaptivecards/templating/TemplateEngine.kt
+++ b/android/ac-templating/src/main/kotlin/com/microsoft/adaptivecards/templating/TemplateEngine.kt
@@ -1,10 +1,61 @@
 package com.microsoft.adaptivecards.templating
 
+import org.json.JSONObject
+
 /**
  * Template engine for expanding Adaptive Card templates with data binding
  */
 class TemplateEngine {
     private val parser = ExpressionParser()
+
+    /**
+     * Resolve `${rs:key}` string resource references in a raw JSON string.
+     * Must be called **before** template expansion or JSON parsing.
+     *
+     * @param json Raw card JSON string (may contain `${rs:key}` references)
+     * @param locale Preferred locale for localized values (e.g. "en-US"). Falls back to `defaultValue`.
+     * @return JSON string with all valid `${rs:key}` patterns replaced
+     */
+    fun resolveStringResources(json: String, locale: String? = null): String {
+        val root = try { JSONObject(json) } catch (_: Exception) { return json }
+        val resources = root.optJSONObject("resources") ?: return json
+        val strings = resources.optJSONObject("strings") ?: return json
+
+        // Build a flat lookup: key -> resolved string
+        val lookup = mutableMapOf<String, String>()
+        for (key in strings.keys()) {
+            val entry = strings.optJSONObject(key) ?: continue
+            val defaultValue = entry.optString("defaultValue", "")
+
+            if (locale != null) {
+                val localizedValues = entry.optJSONObject("localizedValues")
+                if (localizedValues != null) {
+                    // Case-insensitive locale match
+                    val resolved = localizedValues.keys().asSequence().firstOrNull { localeKey ->
+                        localeKey.equals(locale, ignoreCase = true)
+                    }?.let { localizedValues.optString(it) }
+                    lookup[key] = resolved ?: defaultValue
+                } else {
+                    lookup[key] = defaultValue
+                }
+            } else {
+                lookup[key] = defaultValue
+            }
+        }
+
+        if (lookup.isEmpty()) return json
+
+        // Replace all ${rs:key} patterns (case-sensitive: only lowercase "rs:" is valid)
+        var result = json
+        for ((key, value) in lookup) {
+            val escapedValue = value
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+            result = result.replace("\${rs:$key}", escapedValue)
+        }
+
+        return result
+    }
 
     /**
      * Expand a template string with data binding

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -55,6 +55,7 @@ lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-com
 
 # Image Loading
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
+coil-svg = { module = "io.coil-kt:coil-svg", version.ref = "coil" }
 
 # Testing
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }

--- a/docs/architecture/PARITY_MATRIX.md
+++ b/docs/architecture/PARITY_MATRIX.md
@@ -57,6 +57,7 @@ This document provides a comprehensive feature-by-feature matrix tracking implem
 | **Input.Toggle** | ✅ | ✅ | ✅ iOS: ACInputsTests<br>✅ Android: ToggleInputTests | Toggle switch/checkbox with custom value mapping |
 | **Input.ChoiceSet** | ✅ | ✅ | ✅ iOS: ACInputsTests<br>✅ Android: ChoiceSetInputTests | Compact (dropdown), expanded (radio/checkbox), filtered styles; single/multi-select |
 | **Input.Rating** | ✅ | ✅ | ✅ iOS: ACInputsTests<br>✅ Android: RatingInputTests | Star rating input with max rating, size, color customization |
+| **Input.DataGrid** | ✅ | ✅ | ✅ iOS: ACInputsTests<br>✅ Android: DataGridInputTests | Editable data grid with columns, rows, sorting (v1.5+) |
 
 ---
 
@@ -98,6 +99,9 @@ This document provides a comprehensive feature-by-feature matrix tracking implem
 | **Action.ShowCard** | ✅ | ✅ | ✅ iOS: ACActionsTests<br>✅ Android: ShowCardActionTests | Inline card expansion with animation (v1.0) |
 | **Action.ToggleVisibility** | ✅ | ✅ | ✅ iOS: ACActionsTests<br>✅ Android: ToggleVisibilityTests | Show/hide elements by ID with animation (v1.2) |
 | **Action.Execute** | ✅ | ✅ | ✅ iOS: ACActionsTests<br>✅ Android: ExecuteActionTests | Universal action handler for bot operations (v1.4), enhanced in v1.6 with verb and associatedInputs |
+| **Action.Popover** | ✅ | ✅ | ✅ iOS: ACActionsTests<br>✅ Android: ActionTests | Popover with title, body elements, dismiss behavior (Teams extension) |
+| **Action.RunCommands** | ✅ | ✅ | ✅ iOS: ACActionsTests<br>✅ Android: ActionTests | Execute commands with type, id, data (Teams extension) |
+| **Action.OpenUrlDialog** | ✅ | ✅ | ✅ iOS: ACActionsTests<br>✅ Android: ActionTests | Open URL in dialog with title (Teams extension) |
 
 ---
 

--- a/ios/Sources/ACActions/ShowCardActionHandler.swift
+++ b/ios/Sources/ACActions/ShowCardActionHandler.swift
@@ -9,8 +9,9 @@ public class ShowCardActionHandler {
     }
 
     public func handle(_ action: ShowCardAction) {
-        // Generate a unique ID for this show card action
-        let cardId = action.id ?? UUID().uuidString
+        // Use action.id if available, otherwise generate a stable fallback
+        // matching the CardAction.Identifiable.id pattern
+        let cardId = action.id ?? "showCard_\(action.title ?? "unknown")"
         toggleCard(cardId)
     }
 }

--- a/ios/Sources/ACCore/Models/AdaptiveCard.swift
+++ b/ios/Sources/ACCore/Models/AdaptiveCard.swift
@@ -17,6 +17,7 @@ public struct AdaptiveCard: Codable, Equatable {
     public var authentication: Authentication?
     public var metadata: [String: AnyCodable]?
     public var rtl: Bool?
+    public var references: [DocumentReference]?
 
     enum CodingKeys: String, CodingKey {
         case type
@@ -35,6 +36,7 @@ public struct AdaptiveCard: Codable, Equatable {
         case authentication
         case metadata
         case rtl
+        case references
     }
 
     public init(
@@ -52,7 +54,8 @@ public struct AdaptiveCard: Codable, Equatable {
         refresh: Refresh? = nil,
         authentication: Authentication? = nil,
         metadata: [String: AnyCodable]? = nil,
-        rtl: Bool? = nil
+        rtl: Bool? = nil,
+        references: [DocumentReference]? = nil
     ) {
         self.version = version
         self.schema = schema
@@ -69,6 +72,7 @@ public struct AdaptiveCard: Codable, Equatable {
         self.authentication = authentication
         self.metadata = metadata
         self.rtl = rtl
+        self.references = references
     }
 
     // Custom decoder to allow missing version in sub-cards (Action.ShowCard)
@@ -103,5 +107,32 @@ public struct AdaptiveCard: Codable, Equatable {
         self.authentication = try container.decodeIfPresent(Authentication.self, forKey: .authentication)
         self.metadata = try container.decodeIfPresent([String: AnyCodable].self, forKey: .metadata)
         self.rtl = try container.decodeIfPresent(Bool.self, forKey: .rtl)
+        self.references = try container.decodeIfPresent([DocumentReference].self, forKey: .references)
+    }
+}
+
+// MARK: - DocumentReference
+
+/// A reference entry for CitationRun inlines.
+/// Parsed from the top-level `references` array in an AdaptiveCard.
+public struct DocumentReference: Codable, Equatable {
+    public var type: String?
+    public var title: String?
+    public var icon: String?
+    public var url: String?
+    public var abstract: String?
+
+    public init(
+        type: String? = nil,
+        title: String? = nil,
+        icon: String? = nil,
+        url: String? = nil,
+        abstract: String? = nil
+    ) {
+        self.type = type
+        self.title = title
+        self.icon = icon
+        self.url = url
+        self.abstract = abstract
     }
 }

--- a/ios/Sources/ACCore/Models/CardAction.swift
+++ b/ios/Sources/ACCore/Models/CardAction.swift
@@ -295,9 +295,14 @@ public struct PopoverAction: BaseAction {
     public var tooltip: String?
     public var isEnabled: Bool?
     public var mode: ActionMode?
-    public var popoverTitle: String?
-    public var popoverBody: [CardElement]?
+    /// The content to display in the popover (single CardElement from JSON "content" field)
+    public var content: CardElement?
     public var dismissBehavior: String?
+
+    enum CodingKeys: String, CodingKey {
+        case type, id, title, iconUrl, style, tooltip, isEnabled, mode
+        case content, dismissBehavior
+    }
 
     public init(
         id: String? = nil,
@@ -307,8 +312,7 @@ public struct PopoverAction: BaseAction {
         tooltip: String? = nil,
         isEnabled: Bool? = nil,
         mode: ActionMode? = nil,
-        popoverTitle: String? = nil,
-        popoverBody: [CardElement]? = nil,
+        content: CardElement? = nil,
         dismissBehavior: String? = nil
     ) {
         self.id = id
@@ -318,8 +322,7 @@ public struct PopoverAction: BaseAction {
         self.tooltip = tooltip
         self.isEnabled = isEnabled
         self.mode = mode
-        self.popoverTitle = popoverTitle
-        self.popoverBody = popoverBody
+        self.content = content
         self.dismissBehavior = dismissBehavior
     }
 }

--- a/ios/Sources/ACCore/Models/ContainerTypes.swift
+++ b/ios/Sources/ACCore/Models/ContainerTypes.swift
@@ -23,8 +23,12 @@ public struct Container: Codable, Equatable {
     public var showBorder: Bool?
     /// When true, apply rounded corners from hostConfig cornerRadius.
     public var roundedCorners: Bool?
-    /// Layout descriptor (FlowLayout or AreaGridLayout). When nil, uses default stack layout.
-    public var layout: Layout?
+    /// Layout descriptors (FlowLayout or AreaGridLayout). When nil/empty, uses default stack layout.
+    /// JSON uses `layouts` (plural array); the first layout is the active one.
+    public var layouts: [Layout]?
+
+    /// Convenience: the active layout (first in the `layouts` array)
+    public var layout: Layout? { layouts?.first }
 
     public init(
         id: String? = nil,
@@ -44,7 +48,7 @@ public struct Container: Codable, Equatable {
         fallback: CardElement? = nil,
         showBorder: Bool? = nil,
         roundedCorners: Bool? = nil,
-        layout: Layout? = nil
+        layouts: [Layout]? = nil
     ) {
         self.id = id
         self.items = items
@@ -63,7 +67,7 @@ public struct Container: Codable, Equatable {
         self.fallback = fallback
         self.showBorder = showBorder
         self.roundedCorners = roundedCorners
-        self.layout = layout
+        self.layouts = layouts
     }
 }
 
@@ -461,6 +465,11 @@ public struct TableCell: Codable, Equatable, Identifiable {
     public var backgroundImage: BackgroundImage?
     public var minHeight: String?
     public var selectAction: CardAction?
+    /// Layout descriptors for this cell (e.g., Flow layout)
+    public var layouts: [Layout]?
+
+    /// Convenience: the active layout (first in the `layouts` array)
+    public var layout: Layout? { layouts?.first }
 
     // Generate stable ID from items IDs
     public var id: String {
@@ -476,7 +485,8 @@ public struct TableCell: Codable, Equatable, Identifiable {
         bleed: Bool? = nil,
         backgroundImage: BackgroundImage? = nil,
         minHeight: String? = nil,
-        selectAction: CardAction? = nil
+        selectAction: CardAction? = nil,
+        layouts: [Layout]? = nil
     ) {
         self.items = items
         self.style = style
@@ -485,6 +495,7 @@ public struct TableCell: Codable, Equatable, Identifiable {
         self.backgroundImage = backgroundImage
         self.minHeight = minHeight
         self.selectAction = selectAction
+        self.layouts = layouts
     }
 }
 

--- a/ios/Sources/ACCore/Models/Elements/CompoundButton.swift
+++ b/ios/Sources/ACCore/Models/Elements/CompoundButton.swift
@@ -31,10 +31,11 @@ public struct CompoundButton: Codable, Equatable {
     public let type: String = "CompoundButton"
     public var id: String?
     public var title: String
-    public var subtitle: String?
+    public var description: String?
     public var icon: IconDescriptor?
     public var iconPosition: String?
-    public var action: CardAction?
+    public var selectAction: CardAction?
+    public var badge: String?
     public var style: String?
     public var isVisible: Bool?
     public var separator: Bool?
@@ -50,10 +51,11 @@ public struct CompoundButton: Codable, Equatable {
     public init(
         id: String? = nil,
         title: String,
-        subtitle: String? = nil,
+        description: String? = nil,
         icon: IconDescriptor? = nil,
         iconPosition: String? = nil,
-        action: CardAction? = nil,
+        selectAction: CardAction? = nil,
+        badge: String? = nil,
         style: String? = nil,
         isVisible: Bool? = nil,
         separator: Bool? = nil,
@@ -63,10 +65,11 @@ public struct CompoundButton: Codable, Equatable {
     ) {
         self.id = id
         self.title = title
-        self.subtitle = subtitle
+        self.description = description
         self.icon = icon
         self.iconPosition = iconPosition
-        self.action = action
+        self.selectAction = selectAction
+        self.badge = badge
         self.style = style
         self.isVisible = isVisible
         self.separator = separator

--- a/ios/Sources/ACCore/Models/MediaTypes.swift
+++ b/ios/Sources/ACCore/Models/MediaTypes.swift
@@ -97,7 +97,7 @@ public struct TextBlock: Codable, Equatable {
 public struct RichTextBlock: Codable, Equatable {
     public let type: String = "RichTextBlock"
     public var id: String?
-    public var inlines: [TextRun]
+    public var inlines: [InlineElement]
     public var horizontalAlignment: HorizontalAlignment?
     public var spacing: Spacing?
     public var separator: Bool?
@@ -108,7 +108,7 @@ public struct RichTextBlock: Codable, Equatable {
 
     public init(
         id: String? = nil,
-        inlines: [TextRun],
+        inlines: [InlineElement],
         horizontalAlignment: HorizontalAlignment? = nil,
         spacing: Spacing? = nil,
         separator: Bool? = nil,
@@ -126,6 +126,75 @@ public struct RichTextBlock: Codable, Equatable {
         self.isVisible = isVisible
         self.requires = requires
         self.fallback = fallback
+    }
+}
+
+// MARK: - InlineElement
+
+/// Polymorphic inline element within a RichTextBlock.
+/// Supports TextRun (styled text) and CitationRun (citation badge).
+public enum InlineElement: Codable, Equatable {
+    case textRun(TextRun)
+    case citationRun(CitationRun)
+
+    enum CodingKeys: String, CodingKey {
+        case type
+    }
+
+    public init(from decoder: Decoder) throws {
+        // Try plain string shorthand first — maps to TextRun
+        if let container = try? decoder.singleValueContainer(),
+           let stringValue = try? container.decode(String.self) {
+            self = .textRun(TextRun(text: stringValue))
+            return
+        }
+
+        // Peek at "type" to determine which inline to decode
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decodeIfPresent(String.self, forKey: .type)
+
+        switch type {
+        case "CitationRun":
+            self = .citationRun(try CitationRun(from: decoder))
+        default:
+            // Default to TextRun for "TextRun" type or missing type
+            self = .textRun(try TextRun(from: decoder))
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .textRun(let textRun):
+            try textRun.encode(to: encoder)
+        case .citationRun(let citationRun):
+            try citationRun.encode(to: encoder)
+        }
+    }
+
+    /// Convenience: the display text for this inline element
+    public var text: String {
+        switch self {
+        case .textRun(let run): return run.text
+        case .citationRun(let run): return run.text
+        }
+    }
+}
+
+// MARK: - CitationRun
+
+/// An inline citation badge that renders as a superscript `[N]` reference.
+public struct CitationRun: Codable, Equatable {
+    public let type: String = "CitationRun"
+    public var text: String
+    public var referenceIndex: Int
+
+    public init(text: String, referenceIndex: Int) {
+        self.text = text
+        self.referenceIndex = referenceIndex
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case type, text, referenceIndex
     }
 }
 

--- a/ios/Sources/ACCore/SchemaValidator.swift
+++ b/ios/Sources/ACCore/SchemaValidator.swift
@@ -14,6 +14,8 @@ public struct SchemaValidator {
         "Container", "ColumnSet", "ImageSet", "FactSet", "ActionSet",
         // Input elements (v1.0)
         "Input.Text", "Input.Number", "Input.Date", "Input.Time", "Input.Toggle", "Input.ChoiceSet",
+        // Input elements (v1.5+)
+        "Input.DataGrid",
         // Advanced elements (v1.3+)
         "Carousel", "Accordion", "CodeBlock", "Rating", "Input.Rating", "ProgressBar", "Spinner",
         "TabSet", "List",

--- a/ios/Sources/ACRendering/ViewModel/ActionHandler.swift
+++ b/ios/Sources/ACRendering/ViewModel/ActionHandler.swift
@@ -56,7 +56,8 @@ public class DefaultActionHandler: ActionHandler {
             handler.handle(toggleAction)
 
         case .popover(let popoverAction):
-            PopoverActionHandler.handle(action: popoverAction, delegate: delegate)
+            let actionId = popoverAction.id ?? "popover_\(popoverAction.title ?? UUID().uuidString)"
+            viewModel.togglePopover(actionId: actionId)
 
         case .runCommands(let runCommandsAction):
             RunCommandsActionHandler.handle(action: runCommandsAction, delegate: delegate)

--- a/ios/Sources/ACRendering/ViewModel/CardViewModel.swift
+++ b/ios/Sources/ACRendering/ViewModel/CardViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Combine
+import SwiftUI
 import ACCore
 import ACTemplating
 
@@ -8,6 +9,7 @@ public class CardViewModel: ObservableObject {
     @Published public var inputValues: [String: Any] = [:]
     @Published public var visibility: [String: Bool] = [:]
     @Published public var showCards: [String: Bool] = [:]
+    @Published public var popoverState: [String: Bool] = [:]
     @Published public var parsingError: Error?
     /// Incremented each time a new parsing error occurs, used for change detection
     @Published public var parsingErrorId: Int = 0
@@ -64,13 +66,14 @@ public class CardViewModel: ObservableObject {
             guard let self = self else { return }
 
             do {
-                var cardJson = json
+                // Resolve ${rs:key} string resources before any other processing
+                var cardJson = self.templateEngine.resolveStringResources(json)
 
                 // If template data provided, expand template first
                 if let data = templateData {
                     self.storedTemplate = json
                     self.storedTemplateData = data
-                    cardJson = try self.templateEngine.expand(template: json, data: data)
+                    cardJson = try self.templateEngine.expand(template: cardJson, data: data)
                 } else {
                     self.storedTemplate = nil
                     self.storedTemplateData = nil
@@ -158,6 +161,24 @@ public class CardViewModel: ObservableObject {
     /// Checks if a show card is expanded
     public func isShowCardExpanded(actionId: String) -> Bool {
         return showCards[actionId] ?? false
+    }
+
+    /// Toggles popover visibility for a given action
+    public func togglePopover(actionId: String) {
+        popoverState[actionId] = !(popoverState[actionId] ?? false)
+    }
+
+    /// Checks if a popover is currently showing for an action
+    public func isPopoverShowing(actionId: String) -> Bool {
+        return popoverState[actionId] ?? false
+    }
+
+    /// Returns a binding for the popover showing state for a given action ID
+    public func popoverBinding(actionId: String) -> Binding<Bool> {
+        Binding(
+            get: { [weak self] in self?.popoverState[actionId] ?? false },
+            set: { [weak self] newValue in self?.popoverState[actionId] = newValue }
+        )
     }
 
     // MARK: - Validation

--- a/ios/Sources/ACRendering/Views/ActionSetView.swift
+++ b/ios/Sources/ACRendering/Views/ActionSetView.swift
@@ -13,19 +13,51 @@ struct ActionSetView: View {
     @EnvironmentObject var viewModel: CardViewModel
 
     var body: some View {
-        Group {
-            if orientation == .horizontal {
-                HStack(spacing: CGFloat(hostConfig.actions.buttonSpacing)) {
-                    actionContent
+        VStack(spacing: CGFloat(hostConfig.actions.buttonSpacing)) {
+            Group {
+                if orientation == .horizontal {
+                    HStack(spacing: CGFloat(hostConfig.actions.buttonSpacing)) {
+                        actionContent
+                    }
+                } else {
+                    VStack(spacing: CGFloat(hostConfig.actions.buttonSpacing)) {
+                        actionContent
+                    }
                 }
-            } else {
-                VStack(spacing: CGFloat(hostConfig.actions.buttonSpacing)) {
-                    actionContent
+            }
+            .frame(maxWidth: .infinity, alignment: alignment)
+
+            // Render expanded ShowCard sub-cards inline
+            ForEach(showCardActions, id: \.id) { action in
+                if case .showCard(let showCardAction) = action,
+                   viewModel.isShowCardExpanded(actionId: action.id) {
+                    VStack(alignment: .leading, spacing: CGFloat(hostConfig.spacing.default)) {
+                        ForEach(Array((showCardAction.card.body ?? []).enumerated()), id: \.offset) { _, element in
+                            ElementView(element: element, hostConfig: hostConfig)
+                        }
+                        // Render sub-card actions if present
+                        if let subActions = showCardAction.card.actions, !subActions.isEmpty {
+                            ActionSetView(actions: subActions, hostConfig: hostConfig)
+                        }
+                    }
+                    .padding(CGFloat(hostConfig.spacing.padding))
+                    .background(
+                        RoundedRectangle(cornerRadius: CGFloat(hostConfig.cornerRadius["container"] ?? 4))
+                            .fill(Color(hex: hostConfig.containerStyles.emphasis.backgroundColor))
+                    )
+                    .transition(.opacity.combined(with: .move(edge: .top)))
                 }
             }
         }
-        .frame(maxWidth: .infinity, alignment: alignment)
         .accessibilityContainer(label: "Actions")
+    }
+
+    /// All ShowCard actions from the action list
+    private var showCardActions: [CardAction] {
+        actions.filter {
+            if case .showCard = $0 { return true }
+            return false
+        }
     }
 
     // MARK: - Overflow logic
@@ -56,16 +88,38 @@ struct ActionSetView: View {
     @ViewBuilder
     private var actionContent: some View {
         ForEach(visibleActions) { action in
-            ActionButton(action: action, hostConfig: hostConfig) {
-                actionHandler.handle(action, delegate: actionDelegate, viewModel: viewModel)
-            }
-            .if(isStretch) { view in
-                view.frame(maxWidth: .infinity)
-            }
+            actionButtonView(for: action)
+                .if(isStretch) { view in
+                    view.frame(maxWidth: .infinity)
+                }
         }
 
         if !overflowActions.isEmpty {
             overflowMenu
+        }
+    }
+
+    @ViewBuilder
+    private func actionButtonView(for action: CardAction) -> some View {
+        if case .popover(let popoverAction) = action {
+            let actionId = popoverAction.id ?? "popover_\(popoverAction.title ?? action.id)"
+            ActionButton(action: action, hostConfig: hostConfig) {
+                actionHandler.handle(action, delegate: actionDelegate, viewModel: viewModel)
+            }
+            .sheet(isPresented: viewModel.popoverBinding(actionId: actionId)) {
+                PopoverContentView(
+                    content: popoverAction.content,
+                    title: popoverAction.title,
+                    hostConfig: hostConfig
+                )
+                .environmentObject(viewModel)
+                .environment(\.actionHandler, actionHandler)
+                .environment(\.actionDelegate, actionDelegate)
+            }
+        } else {
+            ActionButton(action: action, hostConfig: hostConfig) {
+                actionHandler.handle(action, delegate: actionDelegate, viewModel: viewModel)
+            }
         }
     }
 

--- a/ios/Sources/ACRendering/Views/AreaGridLayoutView.swift
+++ b/ios/Sources/ACRendering/Views/AreaGridLayoutView.swift
@@ -22,7 +22,14 @@ public struct AreaGridLayoutView: View {
     }
 
     public var body: some View {
-        if #available(iOS 16.0, *) {
+        if gridLayout.areas.isEmpty {
+            // No areas defined — fall back to vertical stack (graceful degradation)
+            VStack(spacing: spacingValue(gridLayout.rowSpacing ?? .default)) {
+                ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+                    ElementView(element: item, hostConfig: hostConfig)
+                }
+            }
+        } else if #available(iOS 16.0, *) {
             nativeGridView
         } else {
             fallbackGridView

--- a/ios/Sources/ACRendering/Views/CompoundButtonView.swift
+++ b/ios/Sources/ACRendering/Views/CompoundButtonView.swift
@@ -7,6 +7,8 @@ struct CompoundButtonView: View {
     let button: CompoundButton
     let hostConfig: HostConfig
 
+    @Environment(\.actionHandler) var actionHandler
+    @Environment(\.actionDelegate) var actionDelegate
     @EnvironmentObject var viewModel: CardViewModel
 
     private enum Layout {
@@ -16,8 +18,7 @@ struct CompoundButtonView: View {
         static let horizontalPadding: CGFloat = 16
         static let verticalPadding: CGFloat = 12
         static let minHeight: CGFloat = 44
-        static let shadowRadius: CGFloat = 2
-        static let shadowY: CGFloat = 1
+        static let badgeFontSize: CGFloat = 10
     }
 
     var body: some View {
@@ -26,10 +27,10 @@ struct CompoundButtonView: View {
         }
         .buttonStyle(CompoundButtonStyle(
             style: button.style ?? "default",
-            isDisabled: button.action == nil,
+            isDisabled: button.selectAction == nil,
             hostConfig: hostConfig
         ))
-        .disabled(button.action == nil)
+        .disabled(button.selectAction == nil)
         .accessibilityLabel(accessibilityLabel)
         .accessibilityHint(accessibilityHint)
     }
@@ -42,14 +43,27 @@ struct CompoundButtonView: View {
             }
 
             VStack(alignment: .leading, spacing: Layout.titleSubtitleSpacing) {
-                Text(button.title)
-                    .font(.system(size: CGFloat(hostConfig.fontSizes.large), weight: titleFontWeight))
-                    .foregroundColor(Color(hex: hostConfig.containerStyles.default.foregroundColors.default.default))
-                    .lineLimit(2)
-                    .truncationMode(.tail)
+                HStack {
+                    Text(button.title)
+                        .font(.system(size: CGFloat(hostConfig.fontSizes.large), weight: titleFontWeight))
+                        .foregroundColor(Color(hex: hostConfig.containerStyles.default.foregroundColors.default.default))
+                        .lineLimit(2)
+                        .truncationMode(.tail)
 
-                if let subtitle = button.subtitle {
-                    Text(subtitle)
+                    if let badge = button.badge {
+                        Text(badge)
+                            .font(.system(size: Layout.badgeFontSize, weight: .semibold))
+                            .foregroundColor(.white)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(Color(hex: hostConfig.containerStyles.accent.backgroundColor))
+                            .cornerRadius(4)
+                            .lineLimit(1)
+                    }
+                }
+
+                if let description = button.description {
+                    Text(description)
                         .font(.system(size: CGFloat(hostConfig.fontSizes.default)))
                         .foregroundColor(Color(hex: hostConfig.containerStyles.default.foregroundColors.default.subtle))
                         .lineLimit(2)
@@ -126,14 +140,14 @@ struct CompoundButtonView: View {
     }
 
     private var accessibilityLabel: String {
-        if let subtitle = button.subtitle {
-            return "\(button.title). \(subtitle)"
+        if let description = button.description {
+            return "\(button.title). \(description)"
         }
         return button.title
     }
 
     private var accessibilityHint: String {
-        guard let action = button.action else {
+        guard let action = button.selectAction else {
             return ""
         }
 
@@ -160,9 +174,8 @@ struct CompoundButtonView: View {
     }
 
     private func handleAction() {
-        guard let action = button.action else { return }
-        // TODO: Implement action handling through CardViewModel
-        print("CompoundButton action triggered: \(action)")
+        guard let action = button.selectAction else { return }
+        actionHandler.handle(action, delegate: actionDelegate, viewModel: viewModel)
     }
 }
 

--- a/ios/Sources/ACRendering/Views/ImageView.swift
+++ b/ios/Sources/ACRendering/Views/ImageView.swift
@@ -1,7 +1,42 @@
 import SwiftUI
+#if canImport(UIKit)
+import UIKit
+import WebKit
+#endif
 import ACCore
 import ACAccessibility
 import ACFluentUI
+
+#if canImport(UIKit)
+/// A SwiftUI wrapper that renders SVG content via WKWebView
+private struct SVGWebView: UIViewRepresentable {
+    let svgSource: String
+    let width: CGFloat?
+    let height: CGFloat?
+
+    func makeUIView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.isOpaque = false
+        webView.backgroundColor = UIColor.clear
+        webView.scrollView.isScrollEnabled = false
+        webView.scrollView.backgroundColor = UIColor.clear
+        return webView
+    }
+
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        let w = width.map { "\(Int($0))px" } ?? "100%"
+        let h = height.map { "\(Int($0))px" } ?? "auto"
+        let imgTag = "<img src=\"\(svgSource)\" style=\"width:\(w);height:\(h);max-width:100%\">"
+        let html = """
+        <html><head><meta name="viewport" content="width=device-width,initial-scale=1">
+        <style>body{margin:0;padding:0;background:transparent;display:flex;align-items:center;justify-content:center}</style></head>
+        <body>\(imgTag)</body></html>
+        """
+        webView.loadHTMLString(html, baseURL: nil)
+    }
+}
+#endif
 
 struct ImageView: View {
     let image: ACCore.Image
@@ -13,42 +48,48 @@ struct ImageView: View {
     @EnvironmentObject var viewModel: CardViewModel
 
     var body: some View {
-        AsyncImage(url: URL(string: image.url)) { phase in
-            switch phase {
-            case .empty:
-                // Reserve expected size so LazyVGrid/ImageSet can compute row height.
-                // Uses target size if explicit, otherwise a minimal placeholder.
-                if let w = imageWidth, let h = imageHeight {
-                    ProgressView()
-                        .frame(width: w, height: h)
-                } else if shouldFillWidth {
-                    Color.clear
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 1)
-                } else {
-                    Color.clear
-                        .frame(width: 0, height: 0)
+        Group {
+            if isSymbolUrl {
+                // symbol: URLs are platform-specific; render as placeholder
+                Color.clear.frame(width: imageWidth ?? 40, height: imageHeight ?? 40)
+            } else if isSVG {
+                svgView
+            } else {
+                AsyncImage(url: URL(string: image.url)) { phase in
+                    switch phase {
+                    case .empty:
+                        if let w = imageWidth, let h = imageHeight {
+                            ProgressView()
+                                .frame(width: w, height: h)
+                        } else if shouldFillWidth {
+                            Color.clear
+                                .frame(maxWidth: .infinity)
+                                .frame(height: 1)
+                        } else {
+                            Color.clear
+                                .frame(width: 0, height: 0)
+                        }
+                    case .success(let img):
+                        if shouldFillWidth {
+                            img
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(maxWidth: .infinity)
+                                .clipShape(imageShape)
+                        } else {
+                            img
+                                .resizable()
+                                .aspectRatio(contentMode: aspectRatio)
+                                .frame(width: imageWidth, height: imageHeight)
+                                .clipShape(imageShape)
+                        }
+                    case .failure:
+                        Color.clear
+                            .frame(width: 0, height: 0)
+                    @unknown default:
+                        EmptyView()
+                    }
                 }
-            case .success(let img):
-                if shouldFillWidth {
-                    img
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(maxWidth: .infinity)
-                        .clipShape(imageShape)
-                } else {
-                    img
-                        .resizable()
-                        .aspectRatio(contentMode: aspectRatio)
-                        .frame(width: imageWidth, height: imageHeight)
-                        .clipShape(imageShape)
-                }
-            case .failure:
-                // Match Android: silently hide failed images instead of showing placeholder
-                Color.clear
-                    .frame(width: 0, height: 0)
-            @unknown default:
-                EmptyView()
             }
         }
         .background(backgroundColorValue)
@@ -60,6 +101,43 @@ struct ImageView: View {
         }
         .accessibilityElement(label: image.altText ?? "Image")
     }
+
+    // MARK: - SVG Detection & Rendering
+
+    /// True if the URL is SVG content (data URI or .svg URL)
+    private var isSVG: Bool {
+        image.url.hasPrefix("data:image/svg+xml") || {
+            guard let url = URL(string: image.url) else { return false }
+            return url.pathExtension.lowercased() == "svg"
+        }()
+    }
+
+    /// True if the URL uses the symbol: scheme
+    private var isSymbolUrl: Bool {
+        image.url.hasPrefix("symbol:")
+    }
+
+    @ViewBuilder
+    private var svgView: some View {
+        #if canImport(UIKit)
+        SVGWebView(
+            svgSource: image.url,
+            width: imageWidth,
+            height: imageHeight
+        )
+        .frame(
+            width: imageWidth ?? (shouldFillWidth ? nil : 100),
+            height: imageHeight ?? (shouldFillWidth ? 200 : 100)
+        )
+        .frame(maxWidth: shouldFillWidth ? .infinity : nil)
+        .clipShape(imageShape)
+        #else
+        // Fallback for non-UIKit platforms: show placeholder
+        Color.clear.frame(width: imageWidth ?? 100, height: imageHeight ?? 100)
+        #endif
+    }
+
+    // MARK: - Sizing
 
     private var backgroundColorValue: Color {
         if let bgColor = image.backgroundColor, !bgColor.isEmpty {
@@ -114,9 +192,12 @@ struct ImageView: View {
     }
 
     private var imageShape: AnyShape {
-        if image.style == .person {
+        switch image.style {
+        case .person:
             return AnyShape(Circle())
-        } else {
+        case .roundedCorners:
+            return AnyShape(RoundedRectangle(cornerRadius: 8))
+        default:
             let radius = CGFloat(hostConfig.cornerRadius["image"] ?? 0)
             return AnyShape(RoundedRectangle(cornerRadius: radius))
         }

--- a/ios/Sources/ACRendering/Views/PopoverContentView.swift
+++ b/ios/Sources/ACRendering/Views/PopoverContentView.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+import ACCore
+
+/// Bottom sheet view that renders a single CardElement as popover content.
+/// Used by Action.Popover to display contextual content without stealing focus.
+struct PopoverContentView: View {
+    let content: CardElement?
+    let title: String?
+    let hostConfig: HostConfig
+
+    @EnvironmentObject var viewModel: CardViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationView {
+            Group {
+                if let content = content {
+                    ScrollView {
+                        ElementView(element: content, hostConfig: hostConfig)
+                            .environmentObject(viewModel)
+                            .padding(CGFloat(hostConfig.spacing.padding))
+                    }
+                } else {
+                    Text("No content")
+                        .foregroundColor(.secondary)
+                        .padding()
+                }
+            }
+            .navigationTitle(title ?? "")
+            #if canImport(UIKit)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button {
+                        dismiss()
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundColor(.secondary)
+                    }
+                    .accessibilityLabel("Dismiss")
+                }
+            }
+        }
+        #if canImport(UIKit)
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+        #endif
+    }
+}

--- a/ios/Sources/ACRendering/Views/RichTextBlockView.swift
+++ b/ios/Sources/ACRendering/Views/RichTextBlockView.swift
@@ -23,46 +23,76 @@ struct RichTextBlockView: View {
     private var attributedText: AttributedString {
         var result = AttributedString()
 
-        for textRun in richTextBlock.inlines {
-            var runText = AttributedString(textRun.text)
-
-            let size = fontSize(for: textRun)
-            #if canImport(UIKit)
-            let weight = uiFontWeight(for: textRun)
-            runText.font = Font(UIFont.systemFont(ofSize: CGFloat(size), weight: weight))
-            #else
-            runText.font = .system(size: CGFloat(size), weight: swiftUIFontWeight(for: textRun))
-            #endif
-
-            // Apply color
-            runText.foregroundColor = foregroundColor(for: textRun)
-
-            // Apply text styling
-            if textRun.italic == true {
-                runText.font = runText.font?.italic()
+        for inline in richTextBlock.inlines {
+            switch inline {
+            case .textRun(let textRun):
+                result.append(attributedString(for: textRun))
+            case .citationRun(let citationRun):
+                result.append(attributedString(for: citationRun))
             }
-            if textRun.strikethrough == true {
-                runText.strikethroughStyle = .single
-            }
-            if textRun.underline == true {
-                runText.underlineStyle = .single
-            }
-
-            // Highlight support — use HostConfig highlightColors for the active color slot
-            if textRun.highlight == true {
-                runText.backgroundColor = highlightColor(for: textRun)
-            }
-
-            // Link styling for text runs with selectAction
-            if textRun.selectAction != nil {
-                runText.underlineStyle = .single
-                runText.foregroundColor = foregroundColor(for: TextRun(text: textRun.text, color: .accent))
-            }
-
-            result.append(runText)
         }
 
         return result
+    }
+
+    private func attributedString(for textRun: TextRun) -> AttributedString {
+        var runText = AttributedString(textRun.text)
+
+        let size = fontSize(for: textRun)
+        #if canImport(UIKit)
+        let weight = uiFontWeight(for: textRun)
+        runText.font = Font(UIFont.systemFont(ofSize: CGFloat(size), weight: weight))
+        #else
+        runText.font = .system(size: CGFloat(size), weight: swiftUIFontWeight(for: textRun))
+        #endif
+
+        // Apply color
+        runText.foregroundColor = foregroundColor(for: textRun)
+
+        // Apply text styling
+        if textRun.italic == true {
+            runText.font = runText.font?.italic()
+        }
+        if textRun.strikethrough == true {
+            runText.strikethroughStyle = .single
+        }
+        if textRun.underline == true {
+            runText.underlineStyle = .single
+        }
+
+        // Highlight support — use HostConfig highlightColors for the active color slot
+        if textRun.highlight == true {
+            runText.backgroundColor = highlightColor(for: textRun)
+        }
+
+        // Link styling for text runs with selectAction
+        if textRun.selectAction != nil {
+            runText.underlineStyle = .single
+            runText.foregroundColor = foregroundColor(for: TextRun(text: textRun.text, color: .accent))
+        }
+
+        return runText
+    }
+
+    private func attributedString(for citationRun: CitationRun) -> AttributedString {
+        let badgeText = "[\(citationRun.referenceIndex)]"
+        var runText = AttributedString(badgeText)
+
+        // Render as a small superscript-style badge with accent color
+        let accentColor = hostConfig.containerStyles.default.foregroundColors.accent
+        let hex = accentColor.default
+        runText.foregroundColor = Color(hex: hex)
+
+        let smallSize = hostConfig.fontSizes.small
+        #if canImport(UIKit)
+        runText.font = Font(UIFont.systemFont(ofSize: CGFloat(smallSize), weight: .semibold))
+        #else
+        runText.font = .system(size: CGFloat(smallSize), weight: .semibold)
+        #endif
+
+        runText.baselineOffset = 4.0
+
+        return runText
     }
 
     private func fontSize(for textRun: TextRun) -> Int {
@@ -217,5 +247,10 @@ struct RichTextBlockView: View {
 
     private var plainText: String {
         richTextBlock.inlines.map { $0.text }.joined()
+    }
+
+    private func textRunForFontCalc(_ inline: InlineElement) -> TextRun? {
+        if case .textRun(let run) = inline { return run }
+        return nil
     }
 }

--- a/ios/Sources/ACRendering/Views/TableView.swift
+++ b/ios/Sources/ACRendering/Views/TableView.swift
@@ -63,15 +63,26 @@ struct TableCellView: View {
     @EnvironmentObject var viewModel: CardViewModel
 
     var body: some View {
-        VStack(spacing: 0) {
+        Group {
             if let items = cell.items {
-                ForEach(items) { element in
-                    if viewModel.isElementVisible(elementId: element.elementId) {
-                        if isHeader {
-                            ElementView(element: element, hostConfig: hostConfig)
-                                .font(.system(size: CGFloat(hostConfig.fontSizes.default), weight: headerFontWeight))
-                        } else {
-                            ElementView(element: element, hostConfig: hostConfig)
+                if let layout = cell.layout {
+                    switch layout {
+                    case .flow(let flowLayout):
+                        FlowLayoutView(items: items, flowLayout: flowLayout, hostConfig: hostConfig)
+                    case .areaGrid(let gridLayout):
+                        AreaGridLayoutView(items: items, gridLayout: gridLayout, hostConfig: hostConfig)
+                    }
+                } else {
+                    VStack(spacing: 0) {
+                        ForEach(items) { element in
+                            if viewModel.isElementVisible(elementId: element.elementId) {
+                                if isHeader {
+                                    ElementView(element: element, hostConfig: hostConfig)
+                                        .font(.system(size: CGFloat(hostConfig.fontSizes.default), weight: headerFontWeight))
+                                } else {
+                                    ElementView(element: element, hostConfig: hostConfig)
+                                }
+                            }
                         }
                     }
                 }

--- a/ios/Sources/ACTemplating/TemplateEngine.swift
+++ b/ios/Sources/ACTemplating/TemplateEngine.swift
@@ -6,6 +6,56 @@ public final class TemplateEngine {
 
     public init() {}
 
+    // MARK: - String Resources
+
+    /// Resolve `${rs:key}` string resource references in a raw JSON string.
+    /// Must be called **before** template expansion or JSON parsing.
+    ///
+    /// - Parameters:
+    ///   - json: Raw card JSON string (may contain `${rs:key}` references)
+    ///   - locale: Preferred locale for localized values (e.g. "en-US"). Falls back to `defaultValue`.
+    /// - Returns: JSON string with all valid `${rs:key}` patterns replaced
+    public func resolveStringResources(_ json: String, locale: String? = nil) -> String {
+        // Extract the "resources" object from the raw JSON
+        guard let data = json.data(using: .utf8),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let resources = root["resources"] as? [String: Any],
+              let strings = resources["strings"] as? [String: Any] else {
+            return json
+        }
+
+        // Build a flat lookup: key -> resolved string
+        var lookup: [String: String] = [:]
+        for (key, value) in strings {
+            guard let entry = value as? [String: Any] else { continue }
+            let defaultValue = entry["defaultValue"] as? String ?? ""
+
+            if let locale = locale,
+               let localizedValues = entry["localizedValues"] as? [String: String] {
+                // Case-insensitive locale match
+                let resolved = localizedValues.first(where: {
+                    $0.key.caseInsensitiveCompare(locale) == .orderedSame
+                })?.value
+                lookup[key] = resolved ?? defaultValue
+            } else {
+                lookup[key] = defaultValue
+            }
+        }
+
+        guard !lookup.isEmpty else { return json }
+
+        // Replace all ${rs:key} patterns (case-sensitive: only lowercase "rs:" is valid)
+        var result = json
+        for (key, value) in lookup {
+            let escapedValue = value
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "\"", with: "\\\"")
+            result = result.replacingOccurrences(of: "${rs:\(key)}", with: escapedValue)
+        }
+
+        return result
+    }
+
     /// Expand a template string with data binding
     /// - Parameters:
     ///   - template: Template string containing ${...} expressions

--- a/ios/Tests/ACCoreTests/AdvancedElementsParserTests.swift
+++ b/ios/Tests/ACCoreTests/AdvancedElementsParserTests.swift
@@ -729,10 +729,10 @@ final class AdvancedElementsParserTests: XCTestCase {
         if case .compoundButton(let button) = defaultButton {
             XCTAssertEqual(button.id, "btn_default")
             XCTAssertEqual(button.title, "Default Style Button")
-            XCTAssertEqual(button.subtitle, "Leading icon with default styling")
+            XCTAssertEqual(button.description, "Leading icon with default styling")
             XCTAssertEqual(button.iconName, "checkmark.circle.fill")
             XCTAssertEqual(button.iconPosition, "leading")
-            XCTAssertNotNil(button.action)
+            XCTAssertNotNil(button.selectAction)
         } else {
             XCTFail("Expected CompoundButton element")
         }
@@ -752,7 +752,7 @@ final class AdvancedElementsParserTests: XCTestCase {
 
         if case .compoundButton(let button) = emphasisButton {
             XCTAssertEqual(button.style, "emphasis")
-            XCTAssertNotNil(button.action)
+            XCTAssertNotNil(button.selectAction)
         } else {
             XCTFail("Expected CompoundButton with emphasis style")
         }
@@ -773,7 +773,7 @@ final class AdvancedElementsParserTests: XCTestCase {
         if case .compoundButton(let button) = positiveButton {
             XCTAssertEqual(button.style, "positive")
             XCTAssertEqual(button.title, "Approve Request")
-            XCTAssertNotNil(button.action)
+            XCTAssertNotNil(button.selectAction)
         } else {
             XCTFail("Expected CompoundButton with positive style")
         }
@@ -794,7 +794,7 @@ final class AdvancedElementsParserTests: XCTestCase {
         if case .compoundButton(let button) = destructiveButton {
             XCTAssertEqual(button.style, "destructive")
             XCTAssertEqual(button.title, "Delete Item")
-            XCTAssertNotNil(button.action)
+            XCTAssertNotNil(button.selectAction)
         } else {
             XCTFail("Expected CompoundButton with destructive style")
         }
@@ -834,7 +834,7 @@ final class AdvancedElementsParserTests: XCTestCase {
 
         if case .compoundButton(let button) = noIconButton {
             XCTAssertNil(button.icon)
-            XCTAssertNotNil(button.subtitle)
+            XCTAssertNotNil(button.description)
         } else {
             XCTFail("Expected CompoundButton without icon")
         }
@@ -853,9 +853,9 @@ final class AdvancedElementsParserTests: XCTestCase {
         }
 
         if case .compoundButton(let button) = noSubtitleButton {
-            XCTAssertNil(button.subtitle)
+            XCTAssertNil(button.description)
             XCTAssertNotNil(button.icon)
-            XCTAssertNotNil(button.action)
+            XCTAssertNotNil(button.selectAction)
         } else {
             XCTFail("Expected CompoundButton without subtitle")
         }
@@ -874,7 +874,7 @@ final class AdvancedElementsParserTests: XCTestCase {
         }
 
         if case .compoundButton(let button) = disabledButton {
-            XCTAssertNil(button.action)
+            XCTAssertNil(button.selectAction)
         } else {
             XCTFail("Expected CompoundButton without action")
         }
@@ -884,10 +884,10 @@ final class AdvancedElementsParserTests: XCTestCase {
         let button = CompoundButton(
             id: "testButton",
             title: "Test Button",
-            subtitle: "Test subtitle",
+            description: "Test subtitle",
             icon: IconDescriptor(name: "star.fill"),
             iconPosition: "leading",
-            action: CardAction.submit(SubmitAction(title: "Submit")),
+            selectAction: CardAction.submit(SubmitAction(title: "Submit")),
             style: "emphasis"
         )
 
@@ -899,7 +899,7 @@ final class AdvancedElementsParserTests: XCTestCase {
 
         XCTAssertEqual(decoded.id, button.id)
         XCTAssertEqual(decoded.title, button.title)
-        XCTAssertEqual(decoded.subtitle, button.subtitle)
+        XCTAssertEqual(decoded.description, button.description)
         XCTAssertEqual(decoded.icon, button.icon)
         XCTAssertEqual(decoded.iconPosition, button.iconPosition)
         XCTAssertEqual(decoded.style, button.style)

--- a/ios/Tests/ACCoreTests/Resources/compound-buttons.json
+++ b/ios/Tests/ACCoreTests/Resources/compound-buttons.json
@@ -20,10 +20,10 @@
       "type": "CompoundButton",
       "id": "btn_default",
       "title": "Default Style Button",
-      "subtitle": "Leading icon with default styling",
+      "description": "Leading icon with default styling",
       "icon": "checkmark.circle.fill",
       "iconPosition": "leading",
-      "action": {
+      "selectAction": {
         "type": "Action.Submit",
         "title": "Select",
         "data": {
@@ -35,10 +35,10 @@
       "type": "CompoundButton",
       "id": "btn_emphasis",
       "title": "Emphasis Style Button",
-      "subtitle": "With accent color background",
+      "description": "With accent color background",
       "icon": "star.fill",
       "style": "emphasis",
-      "action": {
+      "selectAction": {
         "type": "Action.Submit",
         "title": "Favorite",
         "data": {
@@ -50,10 +50,10 @@
       "type": "CompoundButton",
       "id": "btn_positive",
       "title": "Approve Request",
-      "subtitle": "Positive action with green styling",
+      "description": "Positive action with green styling",
       "icon": "checkmark.circle",
       "style": "positive",
-      "action": {
+      "selectAction": {
         "type": "Action.Submit",
         "title": "Approve",
         "data": {
@@ -66,10 +66,10 @@
       "type": "CompoundButton",
       "id": "btn_destructive",
       "title": "Delete Item",
-      "subtitle": "Destructive action with red styling",
+      "description": "Destructive action with red styling",
       "icon": "trash",
       "style": "destructive",
-      "action": {
+      "selectAction": {
         "type": "Action.Submit",
         "title": "Delete",
         "data": {
@@ -82,10 +82,10 @@
       "type": "CompoundButton",
       "id": "btn_trailing_icon",
       "title": "Trailing Icon Button",
-      "subtitle": "Icon positioned on the right side",
+      "description": "Icon positioned on the right side",
       "icon": "arrow.right.circle",
       "iconPosition": "trailing",
-      "action": {
+      "selectAction": {
         "type": "Action.OpenUrl",
         "title": "Navigate",
         "url": "https://adaptivecards.io"
@@ -95,8 +95,8 @@
       "type": "CompoundButton",
       "id": "btn_no_icon",
       "title": "Button Without Icon",
-      "subtitle": "Only title and subtitle, no icon",
-      "action": {
+      "description": "Only title and subtitle, no icon",
+      "selectAction": {
         "type": "Action.Submit",
         "title": "Submit",
         "data": {
@@ -109,7 +109,7 @@
       "id": "btn_no_subtitle",
       "title": "Button Without Subtitle",
       "icon": "info.circle",
-      "action": {
+      "selectAction": {
         "type": "Action.ShowCard",
         "title": "Show Details",
         "card": {
@@ -128,9 +128,9 @@
       "type": "CompoundButton",
       "id": "btn_url_icon",
       "title": "Button with URL Icon",
-      "subtitle": "Icon loaded from a remote URL",
+      "description": "Icon loaded from a remote URL",
       "icon": "https://adaptivecards.io/content/cats/1.png",
-      "action": {
+      "selectAction": {
         "type": "Action.OpenUrl",
         "title": "Open",
         "url": "https://adaptivecards.io"
@@ -140,9 +140,9 @@
       "type": "CompoundButton",
       "id": "btn_long_text",
       "title": "Button with Very Long Title That Should Truncate Properly with Ellipsis",
-      "subtitle": "And a very long subtitle that also should truncate gracefully when it exceeds the available space in the layout",
+      "description": "And a very long subtitle that also should truncate gracefully when it exceeds the available space in the layout",
       "icon": "ellipsis.circle",
-      "action": {
+      "selectAction": {
         "type": "Action.Submit",
         "title": "Continue",
         "data": {
@@ -154,7 +154,7 @@
       "type": "CompoundButton",
       "id": "btn_disabled",
       "title": "Button Without Action",
-      "subtitle": "This button has no action and should appear disabled",
+      "description": "This button has no action and should appear disabled",
       "icon": "xmark.circle"
     }
   ]

--- a/ios/Tests/ACCoreTests/Resources/popover-action.json
+++ b/ios/Tests/ACCoreTests/Resources/popover-action.json
@@ -20,18 +20,21 @@
       "type": "Action.Popover",
       "title": "Show Details",
       "popoverTitle": "More Information",
-      "popoverBody": [
-        {
-          "type": "TextBlock",
-          "text": "This is a popover modal",
-          "weight": "Bolder"
-        },
-        {
-          "type": "TextBlock",
-          "text": "Popovers display content in a modal sheet or bottom sheet.",
-          "wrap": true
-        }
-      ],
+      "content": {
+        "type": "Container",
+        "items": [
+          {
+            "type": "TextBlock",
+            "text": "This is a popover modal",
+            "weight": "Bolder"
+          },
+          {
+            "type": "TextBlock",
+            "text": "Popovers display content in a modal sheet or bottom sheet.",
+            "wrap": true
+          }
+        ]
+      },
       "dismissBehavior": "manual"
     },
     {

--- a/ios/Tests/IntegrationTests/Resources/compound-buttons.json
+++ b/ios/Tests/IntegrationTests/Resources/compound-buttons.json
@@ -20,10 +20,10 @@
       "type": "CompoundButton",
       "id": "btn_default",
       "title": "Default Style Button",
-      "subtitle": "Leading icon with default styling",
+      "description": "Leading icon with default styling",
       "icon": "checkmark.circle.fill",
       "iconPosition": "leading",
-      "action": {
+      "selectAction": {
         "type": "Action.Submit",
         "title": "Select",
         "data": {
@@ -35,10 +35,10 @@
       "type": "CompoundButton",
       "id": "btn_emphasis",
       "title": "Emphasis Style Button",
-      "subtitle": "With accent color background",
+      "description": "With accent color background",
       "icon": "star.fill",
       "style": "emphasis",
-      "action": {
+      "selectAction": {
         "type": "Action.Submit",
         "title": "Favorite",
         "data": {
@@ -50,10 +50,10 @@
       "type": "CompoundButton",
       "id": "btn_positive",
       "title": "Approve Request",
-      "subtitle": "Positive action with green styling",
+      "description": "Positive action with green styling",
       "icon": "checkmark.circle",
       "style": "positive",
-      "action": {
+      "selectAction": {
         "type": "Action.Submit",
         "title": "Approve",
         "data": {
@@ -66,10 +66,10 @@
       "type": "CompoundButton",
       "id": "btn_destructive",
       "title": "Delete Item",
-      "subtitle": "Destructive action with red styling",
+      "description": "Destructive action with red styling",
       "icon": "trash",
       "style": "destructive",
-      "action": {
+      "selectAction": {
         "type": "Action.Submit",
         "title": "Delete",
         "data": {
@@ -82,10 +82,10 @@
       "type": "CompoundButton",
       "id": "btn_trailing_icon",
       "title": "Trailing Icon Button",
-      "subtitle": "Icon positioned on the right side",
+      "description": "Icon positioned on the right side",
       "icon": "arrow.right.circle",
       "iconPosition": "trailing",
-      "action": {
+      "selectAction": {
         "type": "Action.OpenUrl",
         "title": "Navigate",
         "url": "https://adaptivecards.io"
@@ -95,8 +95,8 @@
       "type": "CompoundButton",
       "id": "btn_no_icon",
       "title": "Button Without Icon",
-      "subtitle": "Only title and subtitle, no icon",
-      "action": {
+      "description": "Only title and subtitle, no icon",
+      "selectAction": {
         "type": "Action.Submit",
         "title": "Submit",
         "data": {
@@ -109,7 +109,7 @@
       "id": "btn_no_subtitle",
       "title": "Button Without Subtitle",
       "icon": "info.circle",
-      "action": {
+      "selectAction": {
         "type": "Action.ShowCard",
         "title": "Show Details",
         "card": {
@@ -128,9 +128,9 @@
       "type": "CompoundButton",
       "id": "btn_url_icon",
       "title": "Button with URL Icon",
-      "subtitle": "Icon loaded from a remote URL",
+      "description": "Icon loaded from a remote URL",
       "icon": "https://adaptivecards.io/content/cats/1.png",
-      "action": {
+      "selectAction": {
         "type": "Action.OpenUrl",
         "title": "Open",
         "url": "https://adaptivecards.io"
@@ -140,9 +140,9 @@
       "type": "CompoundButton",
       "id": "btn_long_text",
       "title": "Button with Very Long Title That Should Truncate Properly with Ellipsis",
-      "subtitle": "And a very long subtitle that also should truncate gracefully when it exceeds the available space in the layout",
+      "description": "And a very long subtitle that also should truncate gracefully when it exceeds the available space in the layout",
       "icon": "ellipsis.circle",
-      "action": {
+      "selectAction": {
         "type": "Action.Submit",
         "title": "Continue",
         "data": {
@@ -154,7 +154,7 @@
       "type": "CompoundButton",
       "id": "btn_disabled",
       "title": "Button Without Action",
-      "subtitle": "This button has no action and should appear disabled",
+      "description": "This button has no action and should appear disabled",
       "icon": "xmark.circle"
     }
   ]

--- a/ios/Tests/IntegrationTests/Resources/popover-action.json
+++ b/ios/Tests/IntegrationTests/Resources/popover-action.json
@@ -20,18 +20,21 @@
       "type": "Action.Popover",
       "title": "Show Details",
       "popoverTitle": "More Information",
-      "popoverBody": [
-        {
-          "type": "TextBlock",
-          "text": "This is a popover modal",
-          "weight": "Bolder"
-        },
-        {
-          "type": "TextBlock",
-          "text": "Popovers display content in a modal sheet or bottom sheet.",
-          "wrap": true
-        }
-      ],
+      "content": {
+        "type": "Container",
+        "items": [
+          {
+            "type": "TextBlock",
+            "text": "This is a popover modal",
+            "weight": "Bolder"
+          },
+          {
+            "type": "TextBlock",
+            "text": "Popovers display content in a modal sheet or bottom sheet.",
+            "wrap": true
+          }
+        ]
+      },
       "dismissBehavior": "manual"
     },
     {

--- a/shared/scripts/compare-schema-coverage.sh
+++ b/shared/scripts/compare-schema-coverage.sh
@@ -29,15 +29,15 @@ ANDROID_ACTIONS="/tmp/android-actions.txt"
 # Extract element types from iOS
 echo "Extracting iOS element types..."
 if [ -f "$IOS_VALIDATOR" ]; then
-    # Extract from validElementTypes set - stop at closing bracket
-    grep -A 20 "validElementTypes" "$IOS_VALIDATOR" | \
+    # Extract element types: only lines between "validElementTypes" set declaration and its closing "]"
+    awk '/static let validElementTypes/,/^    \]/' "$IOS_VALIDATOR" | \
         grep -o '"[^"]*"' | \
         tr -d '"' | \
         grep -E "^[A-Z]|^Input\." | \
         sort -u > "$IOS_ELEMENTS"
-    
-    # Extract action types
-    grep -A 10 "validActionTypes" "$IOS_VALIDATOR" | \
+
+    # Extract action types: only lines between "validActionTypes" set declaration and its closing "]"
+    awk '/static let validActionTypes/,/^    \]/' "$IOS_VALIDATOR" | \
         grep -o '"Action\.[^"]*"' | \
         tr -d '"' | \
         sort -u > "$IOS_ACTIONS"
@@ -49,15 +49,15 @@ fi
 # Extract element types from Android
 echo "Extracting Android element types..."
 if [ -f "$ANDROID_VALIDATOR" ]; then
-    # Extract from VALID_ELEMENT_TYPES set - stop at closing paren
-    grep -A 20 "VALID_ELEMENT_TYPES" "$ANDROID_VALIDATOR" | \
+    # Extract element types: only lines between "VALID_ELEMENT_TYPES" set declaration and its closing ")"
+    awk '/val VALID_ELEMENT_TYPES/,/^        \)/' "$ANDROID_VALIDATOR" | \
         grep -o '"[^"]*"' | \
         tr -d '"' | \
         grep -E "^[A-Z]|^Input\." | \
         sort -u > "$ANDROID_ELEMENTS"
-    
-    # Extract action types
-    grep -A 10 "VALID_ACTION_TYPES" "$ANDROID_VALIDATOR" | \
+
+    # Extract action types: only lines between "VALID_ACTION_TYPES" set declaration and its closing ")"
+    awk '/val VALID_ACTION_TYPES/,/^        \)/' "$ANDROID_VALIDATOR" | \
         grep -o '"Action\.[^"]*"' | \
         tr -d '"' | \
         sort -u > "$ANDROID_ACTIONS"

--- a/shared/test-cards/compound-buttons.json
+++ b/shared/test-cards/compound-buttons.json
@@ -20,10 +20,10 @@
       "type": "CompoundButton",
       "id": "btn_default",
       "title": "Default Style Button",
-      "subtitle": "Leading icon with default styling",
+      "description": "Leading icon with default styling",
       "icon": "checkmark.circle.fill",
       "iconPosition": "leading",
-      "action": {
+      "selectAction": {
         "type": "Action.Submit",
         "title": "Select",
         "data": {
@@ -35,10 +35,10 @@
       "type": "CompoundButton",
       "id": "btn_emphasis",
       "title": "Emphasis Style Button",
-      "subtitle": "With accent color background",
+      "description": "With accent color background",
       "icon": "star.fill",
       "style": "emphasis",
-      "action": {
+      "selectAction": {
         "type": "Action.Submit",
         "title": "Favorite",
         "data": {
@@ -50,10 +50,10 @@
       "type": "CompoundButton",
       "id": "btn_positive",
       "title": "Approve Request",
-      "subtitle": "Positive action with green styling",
+      "description": "Positive action with green styling",
       "icon": "checkmark.circle",
       "style": "positive",
-      "action": {
+      "selectAction": {
         "type": "Action.Submit",
         "title": "Approve",
         "data": {
@@ -66,10 +66,10 @@
       "type": "CompoundButton",
       "id": "btn_destructive",
       "title": "Delete Item",
-      "subtitle": "Destructive action with red styling",
+      "description": "Destructive action with red styling",
       "icon": "trash",
       "style": "destructive",
-      "action": {
+      "selectAction": {
         "type": "Action.Submit",
         "title": "Delete",
         "data": {
@@ -82,10 +82,10 @@
       "type": "CompoundButton",
       "id": "btn_trailing_icon",
       "title": "Trailing Icon Button",
-      "subtitle": "Icon positioned on the right side",
+      "description": "Icon positioned on the right side",
       "icon": "arrow.right.circle",
       "iconPosition": "trailing",
-      "action": {
+      "selectAction": {
         "type": "Action.OpenUrl",
         "title": "Navigate",
         "url": "https://adaptivecards.io"
@@ -95,8 +95,8 @@
       "type": "CompoundButton",
       "id": "btn_no_icon",
       "title": "Button Without Icon",
-      "subtitle": "Only title and subtitle, no icon",
-      "action": {
+      "description": "Only title and subtitle, no icon",
+      "selectAction": {
         "type": "Action.Submit",
         "title": "Submit",
         "data": {
@@ -109,7 +109,7 @@
       "id": "btn_no_subtitle",
       "title": "Button Without Subtitle",
       "icon": "info.circle",
-      "action": {
+      "selectAction": {
         "type": "Action.ShowCard",
         "title": "Show Details",
         "card": {
@@ -128,9 +128,9 @@
       "type": "CompoundButton",
       "id": "btn_url_icon",
       "title": "Button with URL Icon",
-      "subtitle": "Icon loaded from a remote URL",
+      "description": "Icon loaded from a remote URL",
       "icon": "https://adaptivecards.io/content/cats/1.png",
-      "action": {
+      "selectAction": {
         "type": "Action.OpenUrl",
         "title": "Open",
         "url": "https://adaptivecards.io"
@@ -140,9 +140,9 @@
       "type": "CompoundButton",
       "id": "btn_long_text",
       "title": "Button with Very Long Title That Should Truncate Properly with Ellipsis",
-      "subtitle": "And a very long subtitle that also should truncate gracefully when it exceeds the available space in the layout",
+      "description": "And a very long subtitle that also should truncate gracefully when it exceeds the available space in the layout",
       "icon": "ellipsis.circle",
-      "action": {
+      "selectAction": {
         "type": "Action.Submit",
         "title": "Continue",
         "data": {
@@ -154,7 +154,7 @@
       "type": "CompoundButton",
       "id": "btn_disabled",
       "title": "Button Without Action",
-      "subtitle": "This button has no action and should appear disabled",
+      "description": "This button has no action and should appear disabled",
       "icon": "xmark.circle"
     }
   ]

--- a/shared/test-cards/popover-action.json
+++ b/shared/test-cards/popover-action.json
@@ -20,18 +20,21 @@
       "type": "Action.Popover",
       "title": "Show Details",
       "popoverTitle": "More Information",
-      "popoverBody": [
-        {
-          "type": "TextBlock",
-          "text": "This is a popover modal",
-          "weight": "Bolder"
-        },
-        {
-          "type": "TextBlock",
-          "text": "Popovers display content in a modal sheet or bottom sheet.",
-          "wrap": true
-        }
-      ],
+      "content": {
+        "type": "Container",
+        "items": [
+          {
+            "type": "TextBlock",
+            "text": "This is a popover modal",
+            "weight": "Bolder"
+          },
+          {
+            "type": "TextBlock",
+            "text": "Popovers display content in a modal sheet or bottom sheet.",
+            "wrap": true
+          }
+        ]
+      },
       "dismissBehavior": "manual"
     },
     {


### PR DESCRIPTION
## Summary

- **New action types**: Action.Popover, Action.RunCommands, Action.OpenUrlDialog (Teams extensions) on both iOS and Android
- **New element**: Input.DataGrid with schema validator support on both platforms
- **Rendering parity fixes**: ImageView, RichTextBlockView, CompoundButtonView, ActionSetView, TableView, MediaAndTableViews, AreaGridLayoutView improvements across iOS (SwiftUI) and Android (Compose)
- **Templating**: New template engine functions on both platforms
- **Bug fix**: Action.Popover without `id` field silently failed on Android — now generates fallback ID matching iOS behavior
- **Bug fix**: Icon style suffix (e.g. `icon:Open,Filled`) was not stripped before lookup, causing all styled icons to show "?" placeholder on both platforms
- **Icon mappings**: Added ArrowReset and ToggleLeft to all icon resolver tables (iOS + Android ac-rendering + Android ac-actions)
- **Safety**: Use `firstOrNull()` instead of `first()` in Android icon suffix parsing

## Changes (45 files across 3 commits)

| Area | iOS | Android |
|---|---|---|
| Schema validators | SchemaValidator.swift | SchemaValidator.kt |
| Models | AdaptiveCard, CardAction, CompoundButton, ContainerTypes, MediaTypes | AdaptiveCard, CardAction, CardElement, CompoundButton |
| Rendering | ActionSetView, ImageView, RichTextBlockView, CompoundButtonView, TableView, AreaGridLayoutView, PopoverContentView (new) | ActionSetView, ImageView, RichTextBlockView, CompoundButtonView, MediaAndTableViews, LayoutViews |
| Actions | ActionButton.swift (icon suffix fix + new mappings) | ActionButton.kt (icon suffix fix + new mappings) |
| ViewModel | CardViewModel, ActionHandler | CardViewModel |
| Templating | TemplateEngine.swift | TemplateEngine.kt |
| Tests | AdvancedElementsParserTests, test card JSON updates | AdvancedElementsParserTest, test card JSON updates |

## Test plan

- [x] Action.Popover opens bottom sheet on Android (verified on emulator)
- [x] Icons render correctly on iOS v1.5 Action.MenuActions card (verified on simulator)
- [x] Icons render correctly on Android v1.5 Action.MenuActions card (verified on emulator)
- [ ] `cd ios && swift test` — all core/rendering/templating tests pass
- [ ] `cd android && ./gradlew test` — all unit tests pass
- [ ] `bash shared/scripts/compare-schema-coverage.sh` — parity gate passes
- [ ] `bash shared/scripts/validate-test-cards.sh` — test card JSON valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)