### PR TITLE
fix(ios,android): popover fallback ID, icon style suffix parsing

### DIFF
--- a/android/ac-actions/src/main/kotlin/com/microsoft/adaptivecards/actions/ActionButton.kt
+++ b/android/ac-actions/src/main/kotlin/com/microsoft/adaptivecards/actions/ActionButton.kt
@@ -76,7 +76,7 @@ fun ActionButton(
  */
 private fun resolveActionIcon(iconUrl: String): ImageVector? {
     if (!iconUrl.startsWith("icon:")) return null
-    val name = iconUrl.removePrefix("icon:").lowercase()
+    val name = iconUrl.removePrefix("icon:").split(",").firstOrNull()?.lowercase() ?: return null
     return when (name) {
         "alerturgent" -> Icons.Filled.Notifications
         "alert", "bell" -> Icons.Outlined.Notifications
@@ -127,6 +127,8 @@ private fun resolveActionIcon(iconUrl: String): ImageVector? {
         "navigation" -> Icons.Filled.Navigation
         "receipt" -> Icons.Filled.Receipt
         "cart", "cartfilled" -> Icons.Filled.ShoppingCart
+        "arrowreset" -> Icons.Filled.Refresh
+        "toggleleft" -> Icons.Filled.ToggleOn
         else -> null
     }
 }

--- a/android/ac-rendering/src/main/kotlin/com/microsoft/adaptivecards/rendering/composables/ActionSetView.kt
+++ b/android/ac-rendering/src/main/kotlin/com/microsoft/adaptivecards/rendering/composables/ActionSetView.kt
@@ -143,7 +143,7 @@ fun ActionSetView(
         // Render popover bottom sheets for any ActionPopover actions that are showing
         val popoverActions = actions.filterIsInstance<ActionPopover>()
         popoverActions.forEach { popoverAction ->
-            val actionId = popoverAction.id ?: return@forEach
+            val actionId = popoverAction.id ?: "popover_${popoverAction.title ?: "unknown"}"
             if (viewModel.isPopoverShowing(actionId)) {
                 PopoverBottomSheet(
                     action = popoverAction,
@@ -310,9 +310,10 @@ private fun ActionButtonContent(
     }
 }
 
-/** Maps Fluent UI icon names to Material icons. */
+/** Maps Fluent UI icon names to Material icons. Strips style suffixes like ",Filled" or ",Regular". */
 private fun resolveFluentIcon(name: String): ImageVector? {
-    return when (name.lowercase()) {
+    val baseName = name.split(",").firstOrNull()?.lowercase() ?: return null
+    return when (baseName) {
         "alerturgent" -> Icons.Filled.Notifications
         "alert", "bell" -> Icons.Outlined.Notifications
         "belloff" -> Icons.Outlined.Notifications
@@ -361,6 +362,8 @@ private fun resolveFluentIcon(name: String): ImageVector? {
         "chevronup" -> Icons.Filled.ExpandLess
         "navigation" -> Icons.Filled.Navigation
         "receipt" -> Icons.Filled.Receipt
+        "arrowreset" -> Icons.Filled.Refresh
+        "toggleleft" -> Icons.Filled.ToggleOn
         else -> null
     }
 }
@@ -451,7 +454,7 @@ private fun handleAction(
             actionHandler.onOpenUrl(action.url, action.id)
         }
         is ActionPopover -> {
-            val actionId = action.id ?: return
+            val actionId = action.id ?: "popover_${action.title ?: "unknown"}"
             viewModel.togglePopover(actionId)
         }
         is ActionRunCommands -> {

--- a/ios/Sources/ACActions/ActionButton.swift
+++ b/ios/Sources/ACActions/ActionButton.swift
@@ -199,11 +199,15 @@ public struct ActionButton: View {
         "AlertUrgent": "bell.badge",
         "Alert": "exclamationmark.triangle",
         "Bell": "bell",
-        "BellOff": "bell.slash"
+        "BellOff": "bell.slash",
+        "ArrowReset": "arrow.counterclockwise",
+        "ToggleLeft": "switch.2"
     ]
 
-    /// Maps Fluent UI icon names to SF Symbols
+    /// Maps Fluent UI icon names to SF Symbols.
+    /// Handles style suffixes like "Open,Filled" or "Send,Regular" by stripping the comma-separated style.
     static func sfSymbol(for fluentIcon: String) -> String {
-        fluentToSFSymbol[fluentIcon] ?? "questionmark.square"
+        let name = fluentIcon.split(separator: ",").first.map(String.init) ?? fluentIcon
+        return fluentToSFSymbol[name] ?? "questionmark.square"
     }
 }


### PR DESCRIPTION
## Summary

Fixes lost in the PR #60 squash merge — re-applying the bug fix commits.

- **Action.Popover fallback ID**: Generate `"popover_{title}"` when action has no `id` field, fixing popover not opening on Android (iOS already had this pattern)
- **Icon style suffix stripping**: `"icon:Open,Filled"` format now correctly strips `,Filled`/`,Regular` before lookup across all 3 icon resolvers (iOS ActionButton, Android ac-rendering, Android ac-actions)
- **New icon mappings**: ArrowReset and ToggleLeft added on both platforms
- **Safety**: Use `firstOrNull()` instead of `first()` in Android icon suffix splitting

## Files changed (3)

| File | Fix |
|---|---|
| `ios/Sources/ACActions/ActionButton.swift` | Suffix stripping + ArrowReset/ToggleLeft mappings |
| `android/ac-rendering/.../ActionSetView.kt` | Popover fallback ID + suffix stripping + new mappings |
| `android/ac-actions/.../ActionButton.kt` | Suffix stripping + new mappings |

## Test plan

- [x] Action.Popover opens bottom sheet on Android (verified on emulator)
- [x] Icons render on iOS v1.5 Action.MenuActions card (verified on simulator)
- [x] Icons render on Android v1.5 Action.MenuActions card (verified on emulator)
- [x] iOS `swift build` passes
- [x] Android `compileDebugKotlin` passes